### PR TITLE
Feat: 도메인 엔티티 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'mysql:mysql-connector-java:8.0.33'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/openbook/openbook/OpenbookApplication.java
+++ b/src/main/java/com/openbook/openbook/OpenbookApplication.java
@@ -2,7 +2,9 @@ package com.openbook.openbook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OpenbookApplication {
 

--- a/src/main/java/com/openbook/openbook/booth/dto/BoothStatus.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/BoothStatus.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.booth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BoothStatus {
+    WAITING("승인 대기"),
+    APPROVE("승인 완료"),
+    REJECT("승인 거부");
+
+    private final String description;
+}

--- a/src/main/java/com/openbook/openbook/booth/entity/Booth.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/Booth.java
@@ -1,0 +1,83 @@
+package com.openbook.openbook.booth.entity;
+
+import com.openbook.openbook.booth.dto.BoothStatus;
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.global.EntityBasicTime;
+import com.openbook.openbook.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Booth extends EntityBasicTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User manager;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Event linkedEvent;
+
+    private String name;
+
+    private String description;
+
+    private String mainImageUrl;
+
+    private LocalDateTime openTime;
+
+    private LocalDateTime closeTime;
+
+    @Enumerated(EnumType.STRING)
+    private BoothStatus status;
+
+    @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<BoothLocation> locations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<BoothTagDetail> tagDetails = new ArrayList<>();
+
+    @Override
+    public void setPrePersist() {
+        super.setPrePersist();
+        this.status = BoothStatus.WAITING;
+    }
+
+    @Builder
+    public Booth(User manager, Event linkedEvent, String name, String description, String mainImageUrl,
+                 LocalDateTime openTime, LocalDateTime closeTime) {
+        this.manager = manager;
+        this.linkedEvent = linkedEvent;
+        this.name = name;
+        this.description = description;
+        this.mainImageUrl = mainImageUrl;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+    }
+}
+
+
+
+
+
+
+

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothLocation.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothLocation.java
@@ -1,0 +1,37 @@
+package com.openbook.openbook.booth.entity;
+
+
+import com.openbook.openbook.event.entity.EventLayoutArea;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoothLocation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Booth booth;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private EventLayoutArea eventLayoutArea;
+
+    @Builder
+    public BoothLocation(Booth booth, EventLayoutArea eventLayoutArea) {
+        this.booth = booth;
+        this.eventLayoutArea = eventLayoutArea;
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothTag.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothTag.java
@@ -1,0 +1,20 @@
+package com.openbook.openbook.booth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoothTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothTagDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothTagDetail.java
@@ -1,0 +1,36 @@
+package com.openbook.openbook.booth.entity;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoothTagDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Booth booth;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private BoothTag tag;
+
+    @Builder
+    public BoothTagDetail(Booth booth, BoothTag tag) {
+        this.booth = booth;
+        this.tag = tag;
+    }
+
+}

--- a/src/main/java/com/openbook/openbook/event/dto/EventLayoutAreaStatus.java
+++ b/src/main/java/com/openbook/openbook/event/dto/EventLayoutAreaStatus.java
@@ -1,0 +1,11 @@
+package com.openbook.openbook.event.dto;
+
+
+import lombok.Getter;
+
+@Getter
+public enum EventLayoutAreaStatus {
+    EMPTY,
+    WAITING,
+    COMPLETE
+}

--- a/src/main/java/com/openbook/openbook/event/dto/EventLayoutType.java
+++ b/src/main/java/com/openbook/openbook/event/dto/EventLayoutType.java
@@ -1,0 +1,11 @@
+package com.openbook.openbook.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventLayoutType {
+    ALPHABET,
+    NUMBER
+}

--- a/src/main/java/com/openbook/openbook/event/dto/EventStatus.java
+++ b/src/main/java/com/openbook/openbook/event/dto/EventStatus.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.event.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventStatus {
+    WAITING("승인 대기"),
+    APPROVE("승인 완료"),
+    REJECT("승인 거부");
+
+    private final String description;
+}

--- a/src/main/java/com/openbook/openbook/event/entity/Event.java
+++ b/src/main/java/com/openbook/openbook/event/entity/Event.java
@@ -1,0 +1,83 @@
+package com.openbook.openbook.event.entity;
+
+import com.openbook.openbook.event.dto.EventStatus;
+import com.openbook.openbook.global.EntityBasicTime;
+import com.openbook.openbook.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends EntityBasicTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User manager;
+
+    @OneToOne
+    private EventLayout layout;
+
+    private String location;
+
+    private String name;
+
+    private String mainImageUrl;
+
+    private String description;
+
+    private LocalDate openDate;
+
+    private LocalDate closeDate;
+
+    private LocalDate boothRecruitmentStartDate;
+
+    private LocalDate boothRecruitmentEndDate;
+
+    @Enumerated(EnumType.STRING)
+    private EventStatus status;
+
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<EventTagDetail> tagDetails = new ArrayList<>();
+
+    @Override
+    public void setPrePersist() {
+        super.setPrePersist();
+        this.status = EventStatus.WAITING;
+    }
+
+    @Builder
+    public Event(User manager, EventLayout layout, String location, String name, String mainImageUrl,
+                 String description, LocalDate openDate, LocalDate closeDate, LocalDate boothRecruitmentStartDate,
+                 LocalDate boothRecruitmentEndDate) {
+        this.manager = manager;
+        this.layout = layout;
+        this.location = location;
+        this.name = name;
+        this.mainImageUrl = mainImageUrl;
+        this.description = description;
+        this.openDate = openDate;
+        this.closeDate = closeDate;
+        this.boothRecruitmentStartDate = boothRecruitmentStartDate;
+        this.boothRecruitmentEndDate = boothRecruitmentEndDate;
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayout.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayout.java
@@ -1,0 +1,41 @@
+package com.openbook.openbook.event.entity;
+
+import com.openbook.openbook.event.dto.EventLayoutType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventLayout {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private EventLayoutType type;
+
+    @OneToMany(mappedBy = "linkedEventLayout", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<EventLayoutArea> areas = new ArrayList<>();
+
+    @Builder
+    public EventLayout(String imageUrl, EventLayoutType type) {
+        this.imageUrl = imageUrl;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -1,0 +1,56 @@
+package com.openbook.openbook.event.entity;
+
+import com.openbook.openbook.booth.entity.BoothLocation;
+import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventLayoutArea {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private EventLayout linkedEventLayout;
+
+    @Enumerated(EnumType.STRING)
+    private EventLayoutAreaStatus status;
+
+    private String type;
+
+    private String number;
+
+    @OneToMany(mappedBy = "eventLayoutArea", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<BoothLocation> locations = new ArrayList<>();
+
+    @PrePersist
+    public void setFirstEventLayoutAreaStatus() {
+        this.status = EventLayoutAreaStatus.EMPTY;
+    }
+
+    @Builder
+    public EventLayoutArea(EventLayout linkedEventLayout, String type, String number) {
+        this.linkedEventLayout = linkedEventLayout;
+        this.type = type;
+        this.number = number;
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/entity/EventTag.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventTag.java
@@ -1,0 +1,21 @@
+package com.openbook.openbook.event.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/openbook/openbook/event/entity/EventTagDetail.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventTagDetail.java
@@ -1,0 +1,34 @@
+package com.openbook.openbook.event.entity;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventTagDetail {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private EventTag tag;
+
+    @Builder
+    public EventTagDetail(Event event, EventTag tag) {
+        this.event = event;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/openbook/openbook/global/EntityBasicTime.java
+++ b/src/main/java/com/openbook/openbook/global/EntityBasicTime.java
@@ -1,0 +1,26 @@
+package com.openbook.openbook.global;
+
+
+import static java.time.LocalDateTime.now;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class EntityBasicTime {
+    @CreatedDate
+    private LocalDateTime registeredAt;
+
+    @PrePersist
+    public void setPrePersist() {
+        this.registeredAt = now();
+    }
+
+}

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -1,0 +1,22 @@
+package com.openbook.openbook.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmType {
+
+    //EVENT
+    EVENT_REQUEST_RECEIVED("행사 등록 요청이 들어왔습니다."),
+    EVENT_REQUEST_APPROVE("행사 등록 요청이 승인되었습니다."),
+    EVENT_REQUEST_REJECT("행사 등록 요청이 거부되었습니다."),
+
+    //BOOTH
+    BOOTH_REQUEST_RECEIVED("부스 등록 요청이 들어왔습니다."),
+    BOOTH_REQUEST_APPROVE("부스 등록 요청이 승인되었습니다."),
+    BOOTH_REQUEST_REJECT("부스 등록 요청이 거부되었습니다.");
+
+
+    private final String description;
+}

--- a/src/main/java/com/openbook/openbook/user/dto/UserRole.java
+++ b/src/main/java/com/openbook/openbook/user/dto/UserRole.java
@@ -1,0 +1,6 @@
+package com.openbook.openbook.user.dto;
+
+public enum UserRole {
+    ADMIN,
+    USER
+}

--- a/src/main/java/com/openbook/openbook/user/entity/Alarm.java
+++ b/src/main/java/com/openbook/openbook/user/entity/Alarm.java
@@ -1,0 +1,41 @@
+package com.openbook.openbook.user.entity;
+
+import com.openbook.openbook.global.EntityBasicTime;
+import com.openbook.openbook.user.dto.AlarmType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Alarm extends EntityBasicTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User sender;
+
+    @Enumerated(EnumType.STRING)
+    private AlarmType type;
+
+    @Builder
+    public Alarm(User receiver, User sender, AlarmType type) {
+        this.receiver = receiver;
+        this.sender = sender;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/openbook/openbook/user/entity/User.java
+++ b/src/main/java/com/openbook/openbook/user/entity/User.java
@@ -1,0 +1,57 @@
+package com.openbook.openbook.user.entity;
+
+import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.global.EntityBasicTime;
+import com.openbook.openbook.user.dto.UserRole;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends EntityBasicTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String password;
+
+    private String email;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @OneToMany(mappedBy = "manager", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Booth> booths = new ArrayList<>();
+
+    @OneToMany(mappedBy = "manager", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Event> events = new ArrayList<>();
+
+    @OneToMany(mappedBy = "receiver", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Alarm> alarms = new ArrayList<>();
+
+    @Builder
+    public User(String password, String email, String name, UserRole role) {
+        this.password = password;
+        this.email = email;
+        this.name = name;
+        this.role = role;
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #3 

기능 개발에 필요한 entity 구현을 진행했습니다.

## Key Changes
<!-- 주요 수정 사항을 기재해주세요 -->
크게 user, booth, event 로 도메인을 나눠 진행했습니다.
구현된 도메인 별 엔티티와 DTO의 목록은 다음과 같습니다.

**user**
- user
    - userRole
- alarm
    - alarmType

**event**
- event
    - eventStatus
- eventLayout
    - eventLayoutType
- eventLayoutArea
    - eventAreaStatus
- eventTag
- eventTagDetail

**booth**
- booth
    - boothStatus
- boothLocation
- boothTag
- boothTagDetail

생성 시간을 저장하기 위해 공통으로 쓰일 `registeredAt`은 global 패키지로 구분했습니다
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- RDS DB에 들어가면 테이블이 생성된 것을 확인할 수 있습니다.
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/a49a5a67-6d03-40c3-98e9-461578843371)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 실행에 필요한 properties 정보는 노션에 올렸습니다 !
- 어디까지나 필수적인 엔티티만 먼저 설계한 것이기 때문에 이후 기능을 늘리면서 추가하면 될 것 같습니다.
- status 등 enum type의 dto는 추후 프론트분들과의 상의를 거쳐 수정될 수 있을 것 같습니다.
- entity 설계는 기능을 구현한 건 아니여서 커밋 메세지를 feat으로 써도 될지 아리송한데 이와 관련해서 좋은 의견 있으시면 말씀해주시면 감사하겠습니다 !
- 궁금하신 점, 조언 등 편하게 주세요 !
