### PR TITLE
Feat: 예외 전역 처리

### DIFF
--- a/src/main/java/com/openbook/openbook/config/SecurityConfig.java
+++ b/src/main/java/com/openbook/openbook/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.openbook.openbook.config;
 
+import com.openbook.openbook.global.exception.CustomAccessDeniedHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,14 +10,19 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception->{
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                });
 
         http.authorizeHttpRequests(auth -> {
             auth.requestMatchers("/signup").permitAll();

--- a/src/main/java/com/openbook/openbook/global/ResponseMessage.java
+++ b/src/main/java/com/openbook/openbook/global/ResponseMessage.java
@@ -3,4 +3,9 @@ package com.openbook.openbook.global;
 public record ResponseMessage(
         String message
 ) {
+    public String toWrite() {
+        return "{" +
+                "\"message\":" + "\"" + message +"\"" +
+                "}";
+    }
 }

--- a/src/main/java/com/openbook/openbook/global/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/openbook/openbook/global/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.openbook.openbook.global.exception;
+
+
+import com.openbook.openbook.global.ResponseMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write(new ResponseMessage("접근 권한이 존재하지 않습니다.").toWrite());
+    }
+}

--- a/src/main/java/com/openbook/openbook/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/openbook/openbook/global/exception/GlobalControllerAdvice.java
@@ -1,0 +1,33 @@
+package com.openbook.openbook.global.exception;
+
+import com.openbook.openbook.global.ResponseMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    private final String ERROR_LOG = "[ERROR] %s %s";
+
+    @ExceptionHandler(OpenBookException.class)
+    public ResponseEntity<ResponseMessage> applicationException(final OpenBookException e){
+        log.error(String.format(ERROR_LOG, e.getHttpStatus(), e.getMessage()));
+        return ResponseEntity.status(e.getHttpStatus()).body(new ResponseMessage(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseMessage> methodArgumentNotValidException(final MethodArgumentNotValidException e){
+        log.error(String.format(ERROR_LOG, e.getParameter(), "객체검증에러"));
+        return ResponseEntity.badRequest().body(new ResponseMessage("전달된 데이터에 오류가 있습니다."));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ResponseMessage> unexpectedRuntimeException(final RuntimeException e){
+        log.error(String.format(ERROR_LOG, e.getClass().getSimpleName(), e.getMessage()));
+        return ResponseEntity.badRequest().body(new ResponseMessage("예기치 않은 런타임 에러입니다."));
+    }
+}

--- a/src/main/java/com/openbook/openbook/global/exception/OpenBookException.java
+++ b/src/main/java/com/openbook/openbook/global/exception/OpenBookException.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class OpenBookException extends RuntimeException{
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public OpenBookException(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/openbook/openbook/user/UserService.java
+++ b/src/main/java/com/openbook/openbook/user/UserService.java
@@ -1,10 +1,12 @@
 package com.openbook.openbook.user;
 
 
+import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.user.dto.SignUpRequest;
 import com.openbook.openbook.user.dto.UserRole;
 import com.openbook.openbook.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +21,7 @@ public class UserService {
     @Transactional
     public void signup(final SignUpRequest request) {
         if(userRepository.findByEmail(request.email()).isPresent()) {
-            throw new RuntimeException("중복된 이메일");
+            throw new OpenBookException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
         }
         User user = User.builder()
                 .email(request.email())


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #6 

API 요청에서 오류를 반환해야 할 경우의 공통 처리를 구현.
에러를 반환해야 할 경우 OpenBookException 을 사용해 HttpStatus와 message를 반환하면 됩니다.
```java
throw new OpenBookException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
```
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- **SecurityConfig** : 인가 오류 처리 추가 ( accessDeniedHandler )
- **ResponseMessage** : 인가 오류 메세지를 json 형태로 반환할 수 있도록 toWrite 메서드를 추가
- **UserServeice** : 이메일 중복 시, 에러 메세지를 반환하도록 수정
- ExceptionHandler를 관리하는 GlobalControllerAdvice 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- Requset DTO 에 필수 입력값이 입력되지 않았을 경우 (객체 검증 에러)
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/49a7ce66-292f-4954-9b77-9c5b90c3f3b6)

- 회원 가입 시 이미 존재하는 이메일인 경우
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/55cc0218-55b1-4195-807e-691e7db43874)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 이전 프로젝트에서는 ErrorCode로 에러 메세지를 따로 관리했는데, 
이번 PR에서는 그때 그때 status와 message를 반환하도록 구현했는데 어떻게 하는 것이 나을까요?
의견 나눠보면 좋을 것 같습니다 !
- 변수명, 로직 등 궁금한 점이나 조언 편하게 주세요 ! 😀