### PR TITLE
Feat: 승인 요청된 행사 목록 확인

### DIFF
--- a/src/main/java/com/openbook/openbook/config/SecurityConfig.java
+++ b/src/main/java/com/openbook/openbook/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.openbook.openbook.global.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
@@ -2,15 +2,13 @@ package com.openbook.openbook.event.controller;
 
 
 import com.openbook.openbook.event.dto.AdminEventData;
-import com.openbook.openbook.event.dto.PageData;
+import com.openbook.openbook.event.controller.response.PageResponse;
 import com.openbook.openbook.event.service.AdminEventService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,8 +20,11 @@ public class AdminEventController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/admin/events")
-    public ResponseEntity<Page<AdminEventData>> eventList(Pageable pageable) {
-        return ResponseEntity.ok(adminEventService.getEventList(pageable));
-    public ResponseEntity<PageData<AdminEventData>> allEventList(@PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<PageResponse<AdminEventData>> allEventList(@PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(adminEventService.getAllRequestEventList(pageable));
     }
+
 }
+
+
+

--- a/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
@@ -10,6 +10,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,8 +21,9 @@ public class AdminEventController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/admin/events")
-    public ResponseEntity<PageResponse<AdminEventData>> allEventList(@PageableDefault(size = 10) Pageable pageable) {
-        return ResponseEntity.ok(adminEventService.getAllRequestEventList(pageable));
+    public ResponseEntity<PageResponse<AdminEventData>> getEventPage(
+            @RequestParam(defaultValue = "all") String status, @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(PageResponse.of(adminEventService.getRequestedEvents(pageable, status)));
     }
 
 }

--- a/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,10 +20,11 @@ public class AdminEventController {
 
     private final AdminEventService adminEventService;
 
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("#a.name == '1'")
     @GetMapping("/admin/events")
-    public ResponseEntity<PageResponse<AdminEventData>> getEventPage(
-            @RequestParam(defaultValue = "all") String status, @PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<PageResponse<AdminEventData>> getEventPage(Authentication a,
+                                                                     @RequestParam(defaultValue = "all") String status,
+                                                                     @PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(PageResponse.of(adminEventService.getRequestedEvents(pageable, status)));
     }
 

--- a/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
@@ -1,0 +1,26 @@
+package com.openbook.openbook.event.controller;
+
+
+import com.openbook.openbook.event.dto.AdminEventData;
+import com.openbook.openbook.event.service.AdminEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminEventController {
+
+    private final AdminEventService adminEventService;
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/events")
+    public ResponseEntity<Page<AdminEventData>> eventList(Pageable pageable) {
+        return ResponseEntity.ok(adminEventService.getEventList(pageable));
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
@@ -20,10 +20,9 @@ public class AdminEventController {
 
     private final AdminEventService adminEventService;
 
-    @PreAuthorize("#a.name == '1'")
+    @PreAuthorize("authentication.name == '1'")
     @GetMapping("/admin/events")
-    public ResponseEntity<PageResponse<AdminEventData>> getEventPage(Authentication a,
-                                                                     @RequestParam(defaultValue = "all") String status,
+    public ResponseEntity<PageResponse<AdminEventData>> getEventPage(@RequestParam(defaultValue = "all") String status,
                                                                      @PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(PageResponse.of(adminEventService.getRequestedEvents(pageable, status)));
     }

--- a/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/AdminEventController.java
@@ -2,10 +2,12 @@ package com.openbook.openbook.event.controller;
 
 
 import com.openbook.openbook.event.dto.AdminEventData;
+import com.openbook.openbook.event.dto.PageData;
 import com.openbook.openbook.event.service.AdminEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -22,5 +24,6 @@ public class AdminEventController {
     @GetMapping("/admin/events")
     public ResponseEntity<Page<AdminEventData>> eventList(Pageable pageable) {
         return ResponseEntity.ok(adminEventService.getEventList(pageable));
+    public ResponseEntity<PageData<AdminEventData>> allEventList(@PageableDefault(size = 10) Pageable pageable) {
     }
 }

--- a/src/main/java/com/openbook/openbook/event/controller/response/PageResponse.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/PageResponse.java
@@ -1,0 +1,19 @@
+package com.openbook.openbook.event.controller.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T> (
+        int totalPages,
+        int pageNumber,
+        List<T> content
+) {
+    public static <T> PageResponse<T> of(Page<T> page){
+        return new PageResponse<>(
+                page.getTotalPages(),
+                page.getNumber(),
+                page.getContent()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/controller/response/PageResponse.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/PageResponse.java
@@ -12,7 +12,7 @@ public record PageResponse<T> (
     public static <T> PageResponse<T> of(Page<T> page){
         return new PageResponse<>(
                 page.getTotalPages(),
-                page.getNumber(),
+                page.getNumber() + 1,
                 page.getContent()
         );
     }

--- a/src/main/java/com/openbook/openbook/event/dto/AdminEventData.java
+++ b/src/main/java/com/openbook/openbook/event/dto/AdminEventData.java
@@ -1,0 +1,29 @@
+package com.openbook.openbook.event.dto;
+
+import static com.openbook.openbook.global.Formatter.getFormattingDate;
+
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.dto.EventStatus;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+public record AdminEventData(
+        Long id,
+        String name,
+        String location,
+        String registrationDate,
+        String description,
+        @Enumerated(EnumType.STRING)
+        EventStatus status
+) {
+    public static AdminEventData of(Event event) {
+        return new AdminEventData(
+                event.getId(),
+                event.getName(),
+                event.getLocation(),
+                getFormattingDate(event.getRegisteredAt()),
+                event.getDescription(),
+                event.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.event.repository;
 
 import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.dto.EventStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,7 +11,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
 
-    @Query(value = "SELECT * FROM event ORDER BY FIELD(status, 'WAITING'), registered_at", nativeQuery = true)
-    Page<Event> findAllRequest(Pageable pageable);
+    @Query(value = "SELECT * FROM event ORDER BY FIELD(status, 'WAITING', 'APPROVE', 'REJECT'), registered_at", nativeQuery = true)
+    Page<Event> findAllRequested(Pageable pageable);
+
+    @Query("SELECT e FROM Event e WHERE e.status=:status ORDER BY e.registeredAt")
+    Page<Event> findAllRequestedByStatus(Pageable pageable, EventStatus status);
 
 }

--- a/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
@@ -1,10 +1,16 @@
 package com.openbook.openbook.event.repository;
 
 import com.openbook.openbook.event.entity.Event;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Query(value = "SELECT * FROM event ORDER BY FIELD(status, 'WAITING'), registered_at", nativeQuery = true)
+    Page<Event> findAllRequest(Pageable pageable);
 
 }

--- a/src/main/java/com/openbook/openbook/event/service/AdminEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/AdminEventService.java
@@ -1,0 +1,20 @@
+package com.openbook.openbook.event.service;
+
+
+import com.openbook.openbook.event.dto.AdminEventData;
+import com.openbook.openbook.event.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminEventService {
+
+    private final EventRepository eventRepository;
+
+    public Page<AdminEventData> getEventList(Pageable pageable) {
+        return eventRepository.findAllRequest(pageable).map(AdminEventData::of);
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/service/AdminEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/AdminEventService.java
@@ -3,10 +3,16 @@ package com.openbook.openbook.event.service;
 
 import com.openbook.openbook.event.dto.AdminEventData;
 import com.openbook.openbook.event.controller.response.PageResponse;
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.dto.EventStatus;
 import com.openbook.openbook.event.repository.EventRepository;
+import com.openbook.openbook.global.exception.OpenBookException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,8 +20,24 @@ public class AdminEventService {
 
     private final EventRepository eventRepository;
 
-    public PageResponse<AdminEventData> getAllRequestEventList(Pageable pageable) {
-        return PageResponse.of(eventRepository.findAllRequest(pageable).map(AdminEventData::of));
+    @Transactional(readOnly = true)
+    public Page<AdminEventData> getRequestedEvents(Pageable pageable, String status) {
+        if(status.equals("all")) {
+            return eventRepository
+                    .findAllRequested(pageable)
+                    .map(AdminEventData::of);
+        }
+        return eventRepository
+                .findAllRequestedByStatus(pageable, getEventStatus(status))
+                .map(AdminEventData::of);
     }
 
+    private EventStatus getEventStatus(String status) {
+        return switch (status) {
+            case "waiting" -> EventStatus.WAITING;
+            case "approved" -> EventStatus.APPROVE;
+            case "rejected" -> EventStatus.REJECT;
+            default -> throw new OpenBookException(HttpStatus.BAD_REQUEST, "요청 값이 잘못되었습니다.");
+        };
+    }
 }

--- a/src/main/java/com/openbook/openbook/event/service/AdminEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/AdminEventService.java
@@ -2,9 +2,9 @@ package com.openbook.openbook.event.service;
 
 
 import com.openbook.openbook.event.dto.AdminEventData;
+import com.openbook.openbook.event.controller.response.PageResponse;
 import com.openbook.openbook.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +14,8 @@ public class AdminEventService {
 
     private final EventRepository eventRepository;
 
-    public Page<AdminEventData> getEventList(Pageable pageable) {
-        return eventRepository.findAllRequest(pageable).map(AdminEventData::of);
+    public PageResponse<AdminEventData> getAllRequestEventList(Pageable pageable) {
+        return PageResponse.of(eventRepository.findAllRequest(pageable).map(AdminEventData::of));
     }
+
 }

--- a/src/main/java/com/openbook/openbook/global/Formatter.java
+++ b/src/main/java/com/openbook/openbook/global/Formatter.java
@@ -1,0 +1,12 @@
+package com.openbook.openbook.global;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class Formatter {
+
+    public static String getFormattingDate(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return dateTime.format(formatter);
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #20 

관리자가 승인 요청을 받은 행사를 볼 수 있는 기능을 개발했습니다.
동작은 다음과 같습니다.
- status 파라미터로 상태(WAITING, APPROVE, REJECT)별 필터링
- 별도 파라미터 지정이 없거나 all로 주는 경우 전체 목록 확인
- 전체 목록인 경우 WAITING-APPROVE-REJECT 순으로 오름차순 정렬
- 같은 상태의 행사는 신청일이 오래된 순으로 날짜 오름차순 정렬

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- **SecurityConfig**: @EnableMethodSecurity 추가
- **Formatter**: 프론트 UI에 맞게 시간 정보를 포멧팅할 수 있는 메서드 추가 
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/b6844baa-4406-4bde-a06b-cd823c6f4bfb)
- **EventRepository**: 조회 쿼리 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**GET /admin/events**
**?status=(waiting, approved, rejected)**

- 성공
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/9c285341-a0e3-4813-bc59-557d9fdb994d)

- 파라미터값 오류
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/88d3fb8d-0289-477d-8d8d-d2ce2f955f5e)
- 대기중인 행사 목록 /admin/events?status=waiting
- 거부된 행사 목록 /admin/events?status=rejected
- 승인된 행사 목록 /admin/events?status=approved



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 프론트에서 피그마에 ui를 만든대로 0000.00.00 형식으로 반환할 수 있는
Formatter클래스 `getFormattingDate`메서드를 global하게 만들었습니다 !
이후 필요하시면 사용하면 좋을 것 같습니다 ! 😃
- 일반 사용자와 관리자 사용자의 조회를 달리하고자 api 경로에 admin/을 추가했는데,
해당 내용 관련해 다른 좋은 의견이 떠오르시면 말해주시면 감사하겠습니다 !! 
- 권한을 먼저 확인하는 코드인 `@PreAuthorize("#a.name == '1'")`를 원래는 ROLE 을 사용해서 하고 싶었는데,
저희가 UserDetail를 사용해 Role을 부여해줘야 사용이 가능하더라구요!! 그래서 일단 현재 관리자 id인 1이 맞는지 검사하도록 했는데, 작동은 하지만 좋진 않다는 생각이 들어서 이후 role을 사용할 수 있도록 리팩토링 하고자 합니다 !! 
해당 내용은 필수 기능 구현 마치고 따로 브런치로 나눠 진행하겠습니다. 😭
- 개선할 점, 궁금한 점 등 의견 편하게 주세요 !!😃