### PR TITLE
Feat: 행사 상태 변경 API

### DIFF
--- a/src/main/java/com/openbook/openbook/administrator/AdminEventController.java
+++ b/src/main/java/com/openbook/openbook/administrator/AdminEventController.java
@@ -2,13 +2,19 @@ package com.openbook.openbook.administrator;
 
 
 import com.openbook.openbook.administrator.dto.AdminEventData;
+import com.openbook.openbook.administrator.dto.request.EventStatusUpdateRequest;
 import com.openbook.openbook.global.dto.PageResponse;
+import com.openbook.openbook.global.dto.ResponseMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +29,14 @@ public class AdminEventController {
     public ResponseEntity<PageResponse<AdminEventData>> getEventPage(@RequestParam(defaultValue = "all") String status,
                                                                      @PageableDefault(size = 10) Pageable pageable) {
         return ResponseEntity.ok(PageResponse.of(adminEventService.getRequestedEvents(pageable, status)));
+    }
+
+    @PreAuthorize("authentication.name == '1'")
+    @PutMapping("/admin/events/{eventId}/status")
+    public ResponseEntity<ResponseMessage> changeEventStatus (@PathVariable Long eventId,
+                                                              @RequestBody EventStatusUpdateRequest request) {
+        adminEventService.changeEventStatus(eventId, request.status());
+        return ResponseEntity.ok(new ResponseMessage("행사 상태가 변경되었습니다."));
     }
 
 }

--- a/src/main/java/com/openbook/openbook/administrator/AdminEventService.java
+++ b/src/main/java/com/openbook/openbook/administrator/AdminEventService.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.administrator;
 
 import com.openbook.openbook.administrator.dto.AdminEventData;
 import com.openbook.openbook.event.dto.EventStatus;
+import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.repository.EventRepository;
 import com.openbook.openbook.global.exception.OpenBookException;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,18 @@ public class AdminEventService {
         return eventRepository
                 .findAllRequestedByStatus(pageable, getEventStatus(status))
                 .map(AdminEventData::of);
+    }
+
+    @Transactional
+    public void changeEventStatus(Long eventId, EventStatus status) {
+        Event event = getEventOrException(eventId);
+        event.updateStatus(status);
+    }
+
+    private Event getEventOrException(Long id) {
+        return eventRepository.findById(id).orElseThrow(() ->
+                new OpenBookException(HttpStatus.NOT_FOUND, "일치하는 행사가 존재하지 않습니다.")
+        );
     }
 
     private EventStatus getEventStatus(String status) {

--- a/src/main/java/com/openbook/openbook/administrator/dto/request/EventStatusUpdateRequest.java
+++ b/src/main/java/com/openbook/openbook/administrator/dto/request/EventStatusUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.openbook.openbook.administrator.dto.request;
+
+import com.openbook.openbook.event.dto.EventStatus;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+
+public record EventStatusUpdateRequest(
+        @Enumerated(EnumType.STRING)
+        @NotNull EventStatus status
+) {
+}

--- a/src/main/java/com/openbook/openbook/event/entity/Event.java
+++ b/src/main/java/com/openbook/openbook/event/entity/Event.java
@@ -65,6 +65,10 @@ public class Event extends EntityBasicTime {
         this.status = EventStatus.WAITING;
     }
 
+    public void updateStatus(EventStatus status) {
+        this.status = status;
+    }
+
     @Builder
     public Event(User manager, EventLayout layout, String location, String name, String mainImageUrl,
                  String description, LocalDate openDate, LocalDate closeDate, LocalDate boothRecruitmentStartDate,


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #31 

**PUT /admin/events/{eventId}/status**
행사 상태를 승인/거부로 변경하는 API를 개발했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- status 담을 요청 객체 추가
- Event entity 에 status 업데이트를 위한 메서드 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**PUT /admin/events/{eventId}/status**
- 변경할 상태를 담아서 보냅니다.
```java
{
    "status" : "상태"
}
```
들어갈 수 있는 상태는 `APPROVE`, `REJECT`, `WAITING` 3가지입니다.
- 성공시 (200)
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/c9005f83-4524-46b0-9c63-85e023503bb4)
상태가 변경됩니다.

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 개선할 점, 궁금한 점 등 편하게 의견 주세요 !! 😃