### PR TITLE
Fix: 부스 신청시 구역 정보가 저장되지 않는 문제

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
@@ -13,7 +13,7 @@ public record BoothRegistrationRequest(
         @NotNull String openTime,
         @NotNull String closeTime,
         @NotNull MultipartFile mainImage,
-        @NotNull @Size(min = 1, max = 3) List<Long> layoutArea,
+        @NotNull @Size(min = 1, max = 3) List<Long> layoutAreas,
         @NotBlank String description,
         String accountNumber
 

--- a/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
@@ -13,7 +13,7 @@ public record BoothRegistrationRequest(
         @NotNull String openTime,
         @NotNull String closeTime,
         @NotNull MultipartFile mainImage,
-        @NotNull @Size(min = 1, max = 3) List<Long> locations,
+        @NotNull @Size(min = 1, max = 3) List<Long> layoutArea,
         @NotBlank String description,
         String accountNumber
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/BoothLocationService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BoothLocationService.java
@@ -1,53 +1,8 @@
 package com.openbook.openbook.basicuser.service;
 
-import com.openbook.openbook.booth.entity.Booth;
-import com.openbook.openbook.booth.entity.BoothLocation;
-import com.openbook.openbook.booth.repository.BoothLocationRepository;
-import com.openbook.openbook.event.entity.EventLayoutArea;
-import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
-import com.openbook.openbook.event.repository.EventLayoutAreaRepository;
-import com.openbook.openbook.global.exception.OpenBookException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class BoothLocationService {
-    private final EventLayoutAreaRepository eventLayoutAreaRepository;
-    private final BoothLocationRepository boothLocationRepository;
-
-    @Transactional
-    public void boothLocationApplication(List<Long> locations){
-        for(Long layoutId : locations){
-            Optional<EventLayoutArea> eventLayoutArea = eventLayoutAreaRepository.findById(layoutId);
-            EventLayoutArea layoutArea = eventLayoutArea.get();
-            if(layoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
-                layoutArea.updateStatus(EventLayoutAreaStatus.WAITING);
-            }else{
-                throw new OpenBookException(HttpStatus.INTERNAL_SERVER_ERROR, "이미 예약 된 자리 입니다.");
-            }
-        }
-    }
-
-    @Transactional
-    public void createBoothLocation(Booth booth, List<Long> locations){
-        for(Long layoutId : locations){
-            Optional<EventLayoutArea> eventLayoutArea = eventLayoutAreaRepository.findById(layoutId);
-            EventLayoutArea layoutArea = eventLayoutArea.get();
-            if(layoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
-                BoothLocation boothLocation = BoothLocation.builder()
-                        .booth(booth)
-                        .eventLayoutArea(layoutArea)
-                        .build();
-                boothLocationRepository.save(boothLocation);
-            }else{
-                throw new OpenBookException(HttpStatus.INTERNAL_SERVER_ERROR, "이미 예약 된 자리 입니다.");
-            }
-        }
-    }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/BoothLocationService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BoothLocationService.java
@@ -1,8 +1,0 @@
-package com.openbook.openbook.basicuser.service;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-@Service
-@RequiredArgsConstructor
-public class BoothLocationService {
-}

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -56,7 +56,7 @@ public class UserBoothService {
                     .build();
 
             boothRepository.save(booth);
-            userEventLayoutAreaService.boothLocationApplication(request.layoutAreas(), booth);
+            userEventLayoutAreaService.requestBoothLocation(request.layoutAreas(), booth);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -28,6 +28,7 @@ public class UserBoothService {
 
     private final BoothRepository boothRepository;
     private final  BoothLocationService boothLocationService;
+    private final UserEventLayoutAreaService userEventLayoutAreaService;
     private final EventRepository eventRepository;
     private final UserRepository userRepository;
     private final S3Service s3Service;
@@ -55,6 +56,7 @@ public class UserBoothService {
                 .build();
 
         boothRepository.save(booth);
+        userEventLayoutAreaService.registrationBooth(booth, request.locations());
 
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -42,22 +42,23 @@ public class UserBoothService {
 
         dateTimePeriodCheck(open, close, event);
 
-        boothLocationService.boothLocationApplication(request.locations());
+        if(userEventLayoutAreaService.hasReservationData(request.locations())){
+            throw new OpenBookException(HttpStatus.BAD_REQUEST, "이미 예약된 자리 입니다.");
+        }else{
+            Booth booth = Booth.builder()
+                    .linkedEvent(event)
+                    .manager(user)
+                    .name(request.name())
+                    .description(request.description())
+                    .mainImageUrl(uploadAndGetS3ImageUrl(request.mainImage()))
+                    .accountNumber(request.accountNumber())
+                    .openTime(open)
+                    .closeTime(close)
+                    .build();
 
-        Booth booth = Booth.builder()
-                .linkedEvent(event)
-                .manager(user)
-                .name(request.name())
-                .description(request.description())
-                .mainImageUrl(uploadAndGetS3ImageUrl(request.mainImage()))
-                .accountNumber(request.accountNumber())
-                .openTime(open)
-                .closeTime(close)
-                .build();
-
-        boothRepository.save(booth);
-        userEventLayoutAreaService.registrationBooth(booth, request.locations());
-
+            boothRepository.save(booth);
+            userEventLayoutAreaService.boothLocationApplication(request.locations(), booth);
+        }
     }
 
     private void dateTimePeriodCheck(LocalDateTime open, LocalDateTime close, Event event){

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -41,7 +41,7 @@ public class UserBoothService {
 
         dateTimePeriodCheck(open, close, event);
 
-        if(userEventLayoutAreaService.hasReservationData(request.locations())){
+        if(userEventLayoutAreaService.hasReservationData(request.layoutArea())){
             throw new OpenBookException(HttpStatus.BAD_REQUEST, "이미 예약된 자리 입니다.");
         }else{
             Booth booth = Booth.builder()
@@ -56,7 +56,7 @@ public class UserBoothService {
                     .build();
 
             boothRepository.save(booth);
-            userEventLayoutAreaService.boothLocationApplication(request.locations(), booth);
+            userEventLayoutAreaService.boothLocationApplication(request.layoutArea(), booth);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 public class UserBoothService {
 
     private final BoothRepository boothRepository;
-    private final  BoothLocationService boothLocationService;
     private final UserEventLayoutAreaService userEventLayoutAreaService;
     private final EventRepository eventRepository;
     private final UserRepository userRepository;

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -41,7 +41,7 @@ public class UserBoothService {
 
         dateTimePeriodCheck(open, close, event);
 
-        if(userEventLayoutAreaService.hasReservationData(request.layoutArea())){
+        if(userEventLayoutAreaService.hasReservationData(request.layoutAreas())){
             throw new OpenBookException(HttpStatus.BAD_REQUEST, "이미 예약된 자리 입니다.");
         }else{
             Booth booth = Booth.builder()
@@ -56,7 +56,7 @@ public class UserBoothService {
                     .build();
 
             boothRepository.save(booth);
-            userEventLayoutAreaService.boothLocationApplication(request.layoutArea(), booth);
+            userEventLayoutAreaService.boothLocationApplication(request.layoutAreas(), booth);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -50,7 +50,7 @@ public class UserEventLayoutAreaService {
     public boolean hasReservationData(List<Long> eventLayoutAreaList){
         for(Long id : eventLayoutAreaList){
             EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(id).get();
-            if(eventLayoutArea.getBooth() != null){
+            if(eventLayoutArea.getLinkedBooth() != null){
                 return true;
             }
         }

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -11,9 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.openbook.openbook.global.exception.OpenBookException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -3,12 +3,12 @@ package com.openbook.openbook.basicuser.service;
 import com.openbook.openbook.basicuser.dto.LayoutAreaStatusData;
 import com.openbook.openbook.basicuser.dto.LayoutAreaCreateData;
 import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
 import com.openbook.openbook.event.entity.EventLayout;
 import com.openbook.openbook.event.entity.EventLayoutArea;
 import com.openbook.openbook.event.repository.EventLayoutAreaRepository;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.openbook.openbook.global.exception.OpenBookException;
@@ -47,11 +47,24 @@ public class UserEventLayoutAreaService {
                 ));
     }
 
-    public void registrationBooth(Booth booth, List<Long> eventLayoutAreaList){
+    public boolean hasReservationData(List<Long> eventLayoutAreaList){
         for(Long id : eventLayoutAreaList){
-            Optional<EventLayoutArea> eventLayoutArea = layoutAreaRepository.findById(id);
-            EventLayoutArea layoutArea = eventLayoutArea.get();
-            layoutArea.updateBooth(booth);
+            EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(id).get();
+            if(eventLayoutArea.getBooth() != null){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void boothLocationApplication(List<Long> locations, Booth booth){
+        for(Long layoutId : locations){
+            EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(layoutId).get();
+            if(eventLayoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
+                eventLayoutArea.updateStatus(EventLayoutAreaStatus.WAITING, booth);
+            }else{
+                throw new OpenBookException(HttpStatus.INTERNAL_SERVER_ERROR, "이미 예약 된 자리 입니다.");
+            }
         }
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -50,22 +50,17 @@ public class UserEventLayoutAreaService {
     public boolean hasReservationData(List<Long> eventLayoutAreaList){
         for(Long id : eventLayoutAreaList){
             EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(id).get();
-            if(eventLayoutArea.getLinkedBooth() != null){
-                return true;
+            if(eventLayoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     public void boothLocationApplication(List<Long> locations, Booth booth){
         for(Long layoutId : locations){
             EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(layoutId).get();
-            if(eventLayoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
-                eventLayoutArea.updateStatus(EventLayoutAreaStatus.WAITING, booth);
-            }else{
-                throw new OpenBookException(HttpStatus.INTERNAL_SERVER_ERROR, "이미 예약 된 자리 입니다.");
-            }
+            eventLayoutArea.updateBooth(EventLayoutAreaStatus.WAITING, booth);
         }
     }
-
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -48,11 +48,11 @@ public class UserEventLayoutAreaService {
     public boolean hasReservationData(List<Long> eventLayoutAreaList){
         for(Long id : eventLayoutAreaList){
             EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(id).get();
-            if(eventLayoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
-                return false;
+            if(!eventLayoutArea.getStatus().equals(EventLayoutAreaStatus.EMPTY)){
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     public void requestBoothLocation(List<Long> layoutAreas, Booth booth){

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -2,13 +2,18 @@ package com.openbook.openbook.basicuser.service;
 
 import com.openbook.openbook.basicuser.dto.LayoutAreaStatusData;
 import com.openbook.openbook.basicuser.dto.LayoutAreaCreateData;
+import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.event.entity.EventLayout;
 import com.openbook.openbook.event.entity.EventLayoutArea;
 import com.openbook.openbook.event.repository.EventLayoutAreaRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.openbook.openbook.global.exception.OpenBookException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -40,6 +45,14 @@ public class UserEventLayoutAreaService {
                                 Collectors.toList()
                         )
                 ));
+    }
+
+    public void registrationBooth(Booth booth, List<Long> eventLayoutAreaList){
+        for(Long id : eventLayoutAreaList){
+            Optional<EventLayoutArea> eventLayoutArea = layoutAreaRepository.findById(id);
+            EventLayoutArea layoutArea = eventLayoutArea.get();
+            layoutArea.updateBooth(booth);
+        }
     }
 
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutAreaService.java
@@ -55,9 +55,9 @@ public class UserEventLayoutAreaService {
         return true;
     }
 
-    public void boothLocationApplication(List<Long> locations, Booth booth){
-        for(Long layoutId : locations){
-            EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(layoutId).get();
+    public void requestBoothLocation(List<Long> layoutAreas, Booth booth){
+        for(Long layoutAreaId : layoutAreas){
+            EventLayoutArea eventLayoutArea = layoutAreaRepository.findById(layoutAreaId).get();
             eventLayoutArea.updateBooth(EventLayoutAreaStatus.WAITING, booth);
         }
     }

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -63,4 +63,8 @@ public class EventLayoutArea {
         this.linkedBooth = booth;
     }
 
+    public void updateStatus(EventLayoutAreaStatus status){
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.event.entity;
 
+import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothLocation;
 import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
 import jakarta.persistence.CascadeType;
@@ -42,16 +43,20 @@ public class EventLayoutArea {
     @OneToMany(mappedBy = "eventLayoutArea", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<BoothLocation> locations = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Booth booth;
+
     @PrePersist
     public void setFirstEventLayoutAreaStatus() {
         this.status = EventLayoutAreaStatus.EMPTY;
     }
 
     @Builder
-    public EventLayoutArea(EventLayout linkedEventLayout, String classification, String number) {
+    public EventLayoutArea(EventLayout linkedEventLayout, String classification, String number, Booth booth) {
         this.linkedEventLayout = linkedEventLayout;
         this.classification = classification;
         this.number = number;
+        this.booth = booth;
     }
 
     public void updateStatus(EventLayoutAreaStatus status){ this.status = status; }

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -52,12 +52,15 @@ public class EventLayoutArea {
     }
 
     @Builder
-    public EventLayoutArea(EventLayout linkedEventLayout, String classification, String number, Booth booth) {
+    public EventLayoutArea(EventLayout linkedEventLayout, String classification, String number) {
         this.linkedEventLayout = linkedEventLayout;
         this.classification = classification;
         this.number = number;
-        this.booth = booth;
     }
 
     public void updateStatus(EventLayoutAreaStatus status){ this.status = status; }
+
+    public void updateBooth(Booth booth){
+        this.booth = booth;
+    }
 }

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -44,7 +44,7 @@ public class EventLayoutArea {
     private List<BoothLocation> locations = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Booth booth;
+    private Booth linkedBooth;
 
     @PrePersist
     public void setFirstEventLayoutAreaStatus() {
@@ -60,7 +60,7 @@ public class EventLayoutArea {
 
     public void updateStatus(EventLayoutAreaStatus status, Booth booth){
         this.status = status;
-        this.booth = booth;
+        this.linkedBooth = booth;
     }
 
 }

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -58,7 +58,7 @@ public class EventLayoutArea {
         this.number = number;
     }
 
-    public void updateStatus(EventLayoutAreaStatus status, Booth booth){
+    public void updateBooth(EventLayoutAreaStatus status, Booth booth){
         this.status = status;
         this.linkedBooth = booth;
     }

--- a/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventLayoutArea.java
@@ -58,9 +58,9 @@ public class EventLayoutArea {
         this.number = number;
     }
 
-    public void updateStatus(EventLayoutAreaStatus status){ this.status = status; }
-
-    public void updateBooth(Booth booth){
+    public void updateStatus(EventLayoutAreaStatus status, Booth booth){
+        this.status = status;
         this.booth = booth;
     }
+
 }

--- a/src/main/java/com/openbook/openbook/event/repository/EventLayoutAreaRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventLayoutAreaRepository.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.event.repository;
 
+import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.event.entity.EventLayout;
 import com.openbook.openbook.event.entity.EventLayoutArea;
 import java.util.List;
@@ -11,5 +12,8 @@ import org.springframework.stereotype.Repository;
 public interface EventLayoutAreaRepository extends JpaRepository<EventLayoutArea, Long> {
     @Query("SELECT a FROM EventLayoutArea a WHERE a.linkedEventLayout=:linkedLayout")
     List<EventLayoutArea> findAllByLinkedEventLayout(EventLayout linkedLayout);
+
+    @Query("SELECT ea.booth.id FROM EventLayoutArea ea WHERE ea.id=:areaId")
+    Long findBoothById(Long areaId);
 
 }

--- a/src/main/java/com/openbook/openbook/event/repository/EventLayoutAreaRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventLayoutAreaRepository.java
@@ -12,8 +12,4 @@ import org.springframework.stereotype.Repository;
 public interface EventLayoutAreaRepository extends JpaRepository<EventLayoutArea, Long> {
     @Query("SELECT a FROM EventLayoutArea a WHERE a.linkedEventLayout=:linkedLayout")
     List<EventLayoutArea> findAllByLinkedEventLayout(EventLayout linkedLayout);
-
-    @Query("SELECT ea.booth.id FROM EventLayoutArea ea WHERE ea.id=:areaId")
-    Long findBoothById(Long areaId);
-
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #34
행사 구역 테이블에 부스 아이디 칼럼을 추가해 등록시 해당 부스의 아이디가 등록되도록 했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- EventLayoutAreaService에 registrationBooth() 메서드를 추가해서 부스 아이디가 저장되도록 했습니다.
- EventLayoutArea에 updateBooth 메서드를 추가해서 null 이었던 값을 등록 신청한 부스의 아이디로 바뀌게 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 부스 신청시 행사 구역 위치 테이블에 들어가는 모습
<img width="686" alt="image" src="https://github.com/Project-OpenBook/openbook-server/assets/126096318/924c8fc3-27dc-43b6-a326-33f6051455a3">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- EventLayoutArea에 부스 칼럼을 추가할 때 기본 값이 null 이기 때문에 상태 기본 값을 PrePersist 어노테이션으로 지정한 것처럼 null 값 또한 이 어노테이션을 사용해야 하나 고민했으나 현재 사용하지 않아도 크게 문제 없이 작동하기에 따로 선언하지는 않았습니다!
- EventLayoutAreaService 에서 새로 추가한 registrationBooth 메서드가 작동하는 시점에서는 이미 부스가 신청한 위치가 이미 예약된 자리인지 아닌지 이전에 오류 처리를 했기 때문에 따로 한번더 오류 처리를 하지 않았습니다. 혹시 따로 필요하다 싶으시다면 말씀해주세요!
- 이외에도 질문사항이나 의견 있으시면 말씀 부탁드립니다 !