### PR TITLE
Feat: 행사 목록 상황별 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/UserEventController.java
@@ -1,18 +1,25 @@
 package com.openbook.openbook.basicuser.controller;
 
 
+import com.openbook.openbook.basicuser.dto.response.EventBasicData;
 import com.openbook.openbook.basicuser.dto.response.EventLayoutStatus;
 import com.openbook.openbook.basicuser.service.UserEventService;
 import com.openbook.openbook.basicuser.dto.request.EventRegistrationRequest;
+import com.openbook.openbook.global.dto.PageResponse;
 import com.openbook.openbook.global.dto.ResponseMessage;
+import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,5 +38,11 @@ public class UserEventController {
     @GetMapping("/events/{eventId}/layout/status")
     public ResponseEntity<EventLayoutStatus> getEventLayoutStatus(@PathVariable Long eventId) {
         return ResponseEntity.ok(userEventService.getEventLayoutStatus(eventId));
+    }
+
+    @GetMapping("/events")
+    public ResponseEntity<SliceResponse<EventBasicData>> getEvents(@RequestParam(defaultValue = "all") String progress,
+                                                                   @PageableDefault(size = 6) Pageable pageable) {
+        return ResponseEntity.ok(SliceResponse.of(userEventService.getEventBasicData(pageable, progress)));
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/EventBasicData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/EventBasicData.java
@@ -1,0 +1,27 @@
+package com.openbook.openbook.basicuser.dto.response;
+
+import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
+
+import com.openbook.openbook.event.entity.Event;
+
+public record EventBasicData(
+        Long id,
+        String name,
+        String mainImageUrl,
+        String openDate,
+        String closeDate,
+        String recruitStartDate,
+        String recruitEndDate
+) {
+    public static EventBasicData of(Event event) {
+        return new EventBasicData(
+                event.getId(),
+                event.getName(),
+                event.getMainImageUrl(),
+                getFormattingDate(event.getOpenDate().atStartOfDay()),
+                getFormattingDate(event.getCloseDate().atStartOfDay()),
+                getFormattingDate(event.getBoothRecruitmentStartDate().atStartOfDay()),
+                getFormattingDate(event.getBoothRecruitmentEndDate().atStartOfDay())
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -4,6 +4,7 @@ package com.openbook.openbook.basicuser.service;
 import com.openbook.openbook.basicuser.dto.request.EventRegistrationRequest;
 import com.openbook.openbook.basicuser.dto.EventLayoutCreateData;
 import com.openbook.openbook.basicuser.dto.LayoutAreaCreateData;
+import com.openbook.openbook.basicuser.dto.response.EventBasicData;
 import com.openbook.openbook.basicuser.dto.response.EventLayoutStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayout;
@@ -17,6 +18,9 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,6 +60,18 @@ public class UserEventService {
                 .boothRecruitmentEndDate(request.boothRecruitmentEndDate())
                 .build();
         eventRepository.save(event);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<EventBasicData> getEventBasicData(Pageable pageable, String eventProgress) {
+        Slice<Event> events = switch (eventProgress) {
+            case "all" -> eventRepository.findAllApproved(pageable);
+            case "ongoing" -> eventRepository.findAllOnGoing(pageable);
+            case "recruiting" -> eventRepository.findAllRecruiting(pageable);
+            case "terminated" -> eventRepository.findAllTerminated(pageable);
+            default -> throw new OpenBookException(HttpStatus.BAD_REQUEST, "요청 값이 잘못되었습니다.");
+        };
+        return events.map(EventBasicData::of);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -66,7 +66,7 @@ public class UserEventService {
     public Slice<EventBasicData> getEventBasicData(Pageable pageable, String eventProgress) {
         Slice<Event> events = switch (eventProgress) {
             case "all" -> eventRepository.findAllApproved(pageable);
-            case "ongoing" -> eventRepository.findAllOnGoing(pageable);
+            case "ongoing" -> eventRepository.findAllOngoing(pageable);
             case "recruiting" -> eventRepository.findAllRecruiting(pageable);
             case "terminated" -> eventRepository.findAllTerminated(pageable);
             default -> throw new OpenBookException(HttpStatus.BAD_REQUEST, "요청 값이 잘못되었습니다.");

--- a/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
@@ -2,8 +2,10 @@ package com.openbook.openbook.event.repository;
 
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.dto.EventStatus;
+import java.time.LocalDate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -19,5 +21,19 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("SELECT e FROM Event e WHERE e.status=:status ORDER BY e.registeredAt")
     Page<Event> findAllRequestedByStatus(Pageable pageable, EventStatus status);
+
+    // USER
+    @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE'")
+    Slice<Event> findAllApproved(Pageable pageable);
+
+    @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' AND current_date BETWEEN e.openDate AND e.closeDate")
+    Slice<Event> findAllOnGoing(Pageable pageable);
+
+    @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' "
+            + "AND current_date BETWEEN e.boothRecruitmentStartDate AND e.boothRecruitmentEndDate")
+    Slice<Event> findAllRecruiting(Pageable pageable);
+
+    @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' AND e.closeDate <= current_date")
+    Slice<Event> findAllTerminated(Pageable pageable);
 
 }

--- a/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
@@ -27,7 +27,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Slice<Event> findAllApproved(Pageable pageable);
 
     @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' AND current_date BETWEEN e.openDate AND e.closeDate")
-    Slice<Event> findAllOnGoing(Pageable pageable);
+    Slice<Event> findAllOngoing(Pageable pageable);
 
     @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' "
             + "AND current_date BETWEEN e.boothRecruitmentStartDate AND e.boothRecruitmentEndDate")

--- a/src/main/java/com/openbook/openbook/global/dto/SliceResponse.java
+++ b/src/main/java/com/openbook/openbook/global/dto/SliceResponse.java
@@ -1,0 +1,20 @@
+package com.openbook.openbook.global.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+        boolean hasNext,
+        int sliceNumber,
+        int numberOfElements,
+        List<T> content
+) {
+    public static <T> SliceResponse<T> of(Slice<T> slice){
+        return new SliceResponse<>(
+                slice.hasNext(),
+                slice.getNumber(),
+                slice.getNumberOfElements(),
+                slice.getContent()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #35 

**GET /events?page=n&sort=openDate**
일반 회원이 행사 목록을 진행 상황 별로 조회할 수 있는 API 개발
- 참고한 프론트엔드 피그마 화면 : 
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/e8340db5-f606-4c70-920c-32fdc1d12301)
  - 최신 순, 오래된 순은 쿼리의 sort=openDate를 활용해 정렬
  - ongoing, recruiting, terminated 파라미터를 사용해 진행 상황 필터링 가능
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- **global 패키지에 SliceResponse 추가** : Slice 형식의 데이터 매핑용 객체를 생성했습니다.
들어가는 내용은 다음과 같습니다.
  - hasNext : 다음 페이지가 존재하는지
  - sliceNumber : 현재 페이지 (0부터 시작)
  - numberOfElements : 해당 페이지에 존재하는 행사 수


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- **진행 중인 행사 최신 순** /events?page=0&sort=openDate,DESC&progress=ongoing
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/f7efad90-3fae-4ce6-b2bf-89b0907e4974)
- **진행 중인 행사 오래된 순** /events?page=0&sort=openDate,ASC&progress=ongoing
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/1ec0fa27-b5a6-41fa-aa93-97f9c32e1cb9)

- **부스 모집 중인 행사** /events?page=0&sort=openDate&progress=recruiting
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/1158d0fd-b37a-4c11-8a61-439d738e5944)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 구현하면서 행사 엔티티 필드에 있는 부스 모집 시작 기간/ 부스 모집 마감 시간 변수 명이 너무 긴 것 같아서,
추후 좀 짧게 바꾸고 싶다는 생각이 들었습니다 ! 좋은 아이디어나 의견 있으시면 같이 나눠봐요~
- 궁금한 점, 조언 등 편하게 의견 주세요 !😃