### PR TITLE
Feat: 부스 등록 신청 상태 변경 API

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/entity/Booth.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/Booth.java
@@ -64,6 +64,8 @@ public class Booth extends EntityBasicTime {
         this.status = BoothStatus.WAITING;
     }
 
+    public void updateStatus(BoothStatus status){ this.status = status; }
+
     @Builder
     public Booth(User manager, Event linkedEvent, String name, String description, String mainImageUrl,
                  String accountNumber, LocalDateTime openTime, LocalDateTime closeTime) {

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
@@ -24,7 +24,7 @@ public class EventManagerController {
         return ResponseEntity.ok(PageResponse.of(eventManagerService.getBoothManageData(status, eventId, pageable, Long.valueOf(authentication.getName()))));
     }
 
-    @PutMapping("/booths/{boothId}/status")
+    @PutMapping("/events/booths/{boothId}/status")
     public ResponseEntity<ResponseMessage> changeBoothStatus(@PathVariable Long boothId,
                                                              @RequestBody BoothStatusUpdateRequest request, Authentication authentication) {
         eventManagerService.changeBoothStatus(boothId, request.boothStatus(), Long.valueOf(authentication.getName()));

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
@@ -24,7 +24,7 @@ public class EventManagerController {
         return ResponseEntity.ok(PageResponse.of(eventManagerService.getBoothManageData(status, eventId, pageable, Long.valueOf(authentication.getName()))));
     }
 
-    @PostMapping("/booths/{boothId}/status")
+    @PutMapping("/booths/{boothId}/status")
     public ResponseEntity<ResponseMessage> changeBoothStatus(@PathVariable Long boothId,
                                                              @RequestBody BoothStatusUpdateRequest request, Authentication authentication) {
         eventManagerService.changeBoothStatus(boothId, request.boothStatus(), Long.valueOf(authentication.getName()));

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
@@ -1,7 +1,7 @@
 package com.openbook.openbook.eventmanager;
 
 import com.openbook.openbook.eventmanager.dto.BoothManageData;
-import com.openbook.openbook.eventmanager.dto.StatusUpdateRequest;
+import com.openbook.openbook.eventmanager.dto.BoothStatusUpdateRequest;
 import com.openbook.openbook.global.dto.PageResponse;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class EventManagerController {
 
     @PostMapping("/booths/{boothId}/status")
     public ResponseEntity<ResponseMessage> changeBoothStatus(@PathVariable Long boothId,
-                                                             @RequestBody StatusUpdateRequest request) {
+                                                             @RequestBody BoothStatusUpdateRequest request) {
         eventManagerService.changeBoothStatus(boothId, request.boothStatus());
         return ResponseEntity.ok(new ResponseMessage("부스 상태가 변경되었습니다."));
     }

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
@@ -26,8 +26,8 @@ public class EventManagerController {
 
     @PostMapping("/booths/{boothId}/status")
     public ResponseEntity<ResponseMessage> changeBoothStatus(@PathVariable Long boothId,
-                                                             @RequestBody BoothStatusUpdateRequest request) {
-        eventManagerService.changeBoothStatus(boothId, request.boothStatus());
+                                                             @RequestBody BoothStatusUpdateRequest request, Authentication authentication) {
+        eventManagerService.changeBoothStatus(boothId, request.boothStatus(), Long.valueOf(authentication.getName()));
         return ResponseEntity.ok(new ResponseMessage("부스 상태가 변경되었습니다."));
     }
 }

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerController.java
@@ -1,16 +1,15 @@
 package com.openbook.openbook.eventmanager;
 
 import com.openbook.openbook.eventmanager.dto.BoothManageData;
+import com.openbook.openbook.eventmanager.dto.StatusUpdateRequest;
 import com.openbook.openbook.global.dto.PageResponse;
+import com.openbook.openbook.global.dto.ResponseMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +22,12 @@ public class EventManagerController {
                                                                             @PageableDefault(size = 10) Pageable pageable,
                                                                             Authentication authentication){
         return ResponseEntity.ok(PageResponse.of(eventManagerService.getBoothManageData(status, eventId, pageable, Long.valueOf(authentication.getName()))));
+    }
+
+    @PostMapping("/booths/{boothId}/status")
+    public ResponseEntity<ResponseMessage> changeBoothStatus(@PathVariable Long boothId,
+                                                             @RequestBody StatusUpdateRequest request) {
+        eventManagerService.changeBoothStatus(boothId, request.boothStatus());
+        return ResponseEntity.ok(new ResponseMessage("부스 상태가 변경되었습니다."));
     }
 }

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
@@ -60,21 +60,12 @@ public class EventManagerService {
             booth.updateStatus(boothStatus);
             List<EventLayoutArea> eventLayoutAreas = eventLayoutAreaRepository.findAllByLinkedBoothId(boothId);
 
-            if(boothStatus.equals(BoothStatus.APPROVE)){
-                for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
-                    eventLayoutArea.updateStatus(EventLayoutAreaStatus.COMPLETE);
-                }
-            } else if (boothStatus.equals(BoothStatus.REJECT)) {
-                for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
-                    eventLayoutArea.updateStatus(EventLayoutAreaStatus.EMPTY);
-                }
-            }
+            changeAreaStatus(eventLayoutAreas, boothStatus);
         }else{
             throw new OpenBookException(HttpStatus.BAD_REQUEST, "이미 처리된 상태입니다.");
         }
 
     }
-
 
     private BoothManageData convertToBoothManageData(Booth booth) {
         List<EventLayoutArea> eventLayoutAreas = eventLayoutAreaRepository.findAllByLinkedBoothId(booth.getId());
@@ -85,7 +76,6 @@ public class EventManagerService {
         return BoothManageData.of(booth, locationData);
     }
 
-
     private BoothStatus getBoothStatus(String status){
         return switch (status){
             case "waiting" -> BoothStatus.WAITING;
@@ -93,6 +83,18 @@ public class EventManagerService {
             case "rejected" -> BoothStatus.REJECT;
             default -> throw new OpenBookException(HttpStatus.BAD_REQUEST, "요청 값이 잘못되었습니다.");
         };
+    }
+
+    private void changeAreaStatus(List<EventLayoutArea> eventLayoutAreas, BoothStatus boothStatus){
+        if(boothStatus.equals(BoothStatus.APPROVE)){
+            for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
+                eventLayoutArea.updateStatus(EventLayoutAreaStatus.COMPLETE);
+            }
+        } else if (boothStatus.equals(BoothStatus.REJECT)) {
+            for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
+                eventLayoutArea.updateStatus(EventLayoutAreaStatus.EMPTY);
+            }
+        }
     }
 
     private Event getEventOrException(Long id){

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
@@ -62,7 +62,11 @@ public class EventManagerService {
         booth.updateStatus(boothStatus);
         List<EventLayoutArea> eventLayoutAreas = eventLayoutAreaRepository.findAllByLinkedBoothId(boothId);
 
-        changeAreaStatus(eventLayoutAreas, boothStatus);
+        if(boothStatus.equals(BoothStatus.APPROVE)){
+            changeAreaStatus(eventLayoutAreas, EventLayoutAreaStatus.COMPLETE);
+        } else if (boothStatus.equals(BoothStatus.REJECT)) {
+            changeAreaStatus(eventLayoutAreas, EventLayoutAreaStatus.EMPTY);
+        }
 
     }
 
@@ -84,15 +88,9 @@ public class EventManagerService {
         };
     }
 
-    private void changeAreaStatus(List<EventLayoutArea> eventLayoutAreas, BoothStatus boothStatus){
-        if(boothStatus.equals(BoothStatus.APPROVE)){
-            for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
-                eventLayoutArea.updateStatus(EventLayoutAreaStatus.COMPLETE);
-            }
-        } else if (boothStatus.equals(BoothStatus.REJECT)) {
-            for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
-                eventLayoutArea.updateStatus(EventLayoutAreaStatus.EMPTY);
-            }
+    private void changeAreaStatus(List<EventLayoutArea> eventLayoutAreas, EventLayoutAreaStatus eventLayoutAreaStatus){
+        for(EventLayoutArea eventLayoutArea : eventLayoutAreas){
+            eventLayoutArea.updateStatus(eventLayoutAreaStatus);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
@@ -48,8 +48,14 @@ public class EventManagerService {
     }
 
     @Transactional
-    public void changeBoothStatus(Long boothId, BoothStatus boothStatus){
+    public void changeBoothStatus(Long boothId, BoothStatus boothStatus, Long userId){
         Booth booth = getBoothOrException(boothId);
+        User user = getUserOrException(userId);
+
+        if(!booth.getLinkedEvent().getManager().equals(user)){
+            throw new OpenBookException(HttpStatus.BAD_REQUEST, "권한이 존재하지 않습니다.");
+        }
+
         if(!booth.getStatus().equals(boothStatus)){
             booth.updateStatus(boothStatus);
             List<EventLayoutArea> eventLayoutAreas = eventLayoutAreaRepository.findAllByLinkedBoothId(boothId);

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
@@ -56,14 +56,13 @@ public class EventManagerService {
             throw new OpenBookException(HttpStatus.BAD_REQUEST, "권한이 존재하지 않습니다.");
         }
 
-        if(!booth.getStatus().equals(boothStatus)){
-            booth.updateStatus(boothStatus);
-            List<EventLayoutArea> eventLayoutAreas = eventLayoutAreaRepository.findAllByLinkedBoothId(boothId);
-
-            changeAreaStatus(eventLayoutAreas, boothStatus);
-        }else{
+        if(booth.getStatus().equals(boothStatus)){
             throw new OpenBookException(HttpStatus.BAD_REQUEST, "이미 처리된 상태입니다.");
         }
+        booth.updateStatus(boothStatus);
+        List<EventLayoutArea> eventLayoutAreas = eventLayoutAreaRepository.findAllByLinkedBoothId(boothId);
+
+        changeAreaStatus(eventLayoutAreas, boothStatus);
 
     }
 

--- a/src/main/java/com/openbook/openbook/eventmanager/dto/BoothStatusUpdateRequest.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/dto/BoothStatusUpdateRequest.java
@@ -5,7 +5,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 
-public record StatusUpdateRequest(
+public record BoothStatusUpdateRequest(
         @Enumerated(EnumType.STRING)
         @NotNull BoothStatus boothStatus
         ) {

--- a/src/main/java/com/openbook/openbook/eventmanager/dto/StatusUpdateRequest.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/dto/StatusUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.openbook.openbook.eventmanager.dto;
+
+import com.openbook.openbook.booth.dto.BoothStatus;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+
+public record StatusUpdateRequest(
+        @Enumerated(EnumType.STRING)
+        @NotNull BoothStatus boothStatus
+        ) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #39 
해당 행사에 등록을 신청한 부스들의 상태를 변경하는 API 입니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 변경 요청할 부스 상태 데이터를 담는 record 클래스 추가했습니다.
- 이미 승인 / 반려된 상태의 부스를 다시 승인 / 반려 요청했을 경우에 오류를 반환하도록 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 승인 / 반려 를 했을 경우
![image](https://github.com/Project-OpenBook/openbook-server/assets/126096318/829493a3-5ead-4750-80b7-b4d70bddcec4)

- 승인되었거나 반려된 부스에 같은 상태의 데이터를 다시 요청할 경우
![image](https://github.com/Project-OpenBook/openbook-server/assets/126096318/c7c7e421-6712-4416-a20a-7017c2da74d5)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 현재 작성한 controller 클래스에 존재하는 엔드포인트에 관련해서 올바르게 작성한건지 살짝 의문이 들어 의견 나누면 좋겠다 생각합니다!
- 외에도 다른 수정사항이나 질문사항있으시면 말씀해주세요~