### PR TITLE
Feat: 진행중인 모든 부스 목록 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/UserBoothController.java
@@ -1,13 +1,18 @@
 package com.openbook.openbook.basicuser.controller;
 
 import com.openbook.openbook.basicuser.dto.request.BoothRegistrationRequest;
+import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
 import com.openbook.openbook.basicuser.service.UserBoothService;
 import com.openbook.openbook.global.dto.ResponseMessage;
+import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +31,10 @@ public class UserBoothController {
                 .status(HttpStatus.CREATED)
                 .body(new ResponseMessage("신청 완료 되었습니다."));
 
+    }
+
+    @GetMapping
+    public ResponseEntity<SliceResponse<BoothBasicData>> getBooths(@PageableDefault(size = 6)Pageable pageable){
+        return ResponseEntity.ok(SliceResponse.of(userBoothService.getBoothBasicData(pageable)));
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothBasicData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothBasicData.java
@@ -1,0 +1,24 @@
+package com.openbook.openbook.basicuser.dto.response;
+
+import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.event.entity.Event;
+
+import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
+
+public record BoothBasicData(
+        Long id,
+        String name,
+        String openDate,
+        String closeDate,
+        String mainImageUrl
+) {
+    public static BoothBasicData of(Booth booth, Event event){
+        return new BoothBasicData(
+                booth.getId(),
+                booth.getName(),
+                getFormattingDate(event.getOpenDate().atStartOfDay()),
+                getFormattingDate(event.getCloseDate().atStartOfDay()),
+                booth.getMainImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -1,6 +1,8 @@
 package com.openbook.openbook.basicuser.service;
 
 import com.openbook.openbook.basicuser.dto.request.BoothRegistrationRequest;
+import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
+import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.repository.BoothRepository;
 import com.openbook.openbook.event.entity.Event;
@@ -10,6 +12,8 @@ import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.user.repository.UserRepository;
 import com.openbook.openbook.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +62,16 @@ public class UserBoothService {
             boothRepository.save(booth);
             userEventLayoutAreaService.requestBoothLocation(request.layoutAreas(), booth);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<BoothBasicData> getBoothBasicData(Pageable pageable){
+        Slice<Booth> booths = boothRepository.findAllByStatus(BoothStatus.APPROVE, pageable);
+
+        return booths.map(booth -> {
+            Event event = eventRepository.findById(booth.getLinkedEvent().getId()).get();
+            return BoothBasicData.of(booth, event);
+        });
     }
 
     private void dateTimePeriodCheck(LocalDateTime open, LocalDateTime close, Event event){

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -69,8 +69,7 @@ public class UserBoothService {
         Slice<Booth> booths = boothRepository.findAllByStatus(BoothStatus.APPROVE, pageable);
 
         return booths.map(booth -> {
-            Event event = eventRepository.findById(booth.getLinkedEvent().getId()).get();
-            return BoothBasicData.of(booth, event);
+            return BoothBasicData.of(booth, booth.getLinkedEvent());
         });
     }
 

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
@@ -1,13 +1,16 @@
 package com.openbook.openbook.booth.repository;
 
+import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
 
 
 @Repository
@@ -17,4 +20,7 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     @Query(value = "SELECT b FROM Booth b where b.linkedEvent.id =:eventId and b.status =:boothStatus ORDER BY b.registeredAt")
     Page<Booth> findAllBoothByEventIdAndStatus(Pageable pageable, Long eventId, BoothStatus boothStatus);
+
+    @Query("SELECT b FROM Booth b WHERE b.status=:boothStatus")
+    Slice<Booth> findAllByStatus(BoothStatus boothStatus, Pageable pageable);
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #44
서비스에 저장된 모든 부스 중 진행중인 부스들의 목록을 조회하는 기능입니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BasicBoothData record에 응답할 부스의 정보와 해당 연결된 행사의 종료 기간 정보를 담았습니다.
- 모든 부스중 진행중인 상태의 부스만 필터링했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 진행중인 모든 부스 조회 된 결과
<img width="1014" alt="image" src="https://github.com/Project-OpenBook/openbook-server/assets/126096318/f92a299c-8a92-47f8-b8b3-2afb00673e78">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 그 전에 개발 하셨던 행사 목록 api와 변수명이나 클래스명의 통일성을 주고자 최대한 비슷하게 작성했습니다!
- 수정사항이나 질문사항있으시면 말씀해주세요!
