### PR TITLE
Feat: 행사 상세 정보 조회

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/UserEventController.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.basicuser.controller;
 
 
 import com.openbook.openbook.basicuser.dto.response.EventBasicData;
+import com.openbook.openbook.basicuser.dto.response.EventDetail;
 import com.openbook.openbook.basicuser.dto.response.EventLayoutStatus;
 import com.openbook.openbook.basicuser.service.UserEventService;
 import com.openbook.openbook.basicuser.dto.request.EventRegistrationRequest;
@@ -45,4 +46,10 @@ public class UserEventController {
                                                                    @PageableDefault(size = 6) Pageable pageable) {
         return ResponseEntity.ok(SliceResponse.of(userEventService.getEventBasicData(pageable, progress)));
     }
+
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<EventDetail> getEvent(Authentication authentication, @PathVariable Long eventId) {
+        return ResponseEntity.ok(userEventService.getEventDetail(Long.valueOf(authentication.getName()), eventId));
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/EventDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/EventDetail.java
@@ -1,0 +1,35 @@
+package com.openbook.openbook.basicuser.dto.response;
+
+import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
+import static com.openbook.openbook.global.util.JsonService.convertJsonToList;
+
+import com.openbook.openbook.event.entity.Event;
+import java.util.List;
+
+public record EventDetail(
+        Long id,
+        String name,
+        String mainImageUrl,
+        String location,
+        String description,
+        String openDate,
+        String closeDate,
+        List<String> layoutImageUrls,
+        int boothCount,
+        boolean isUserManager
+) {
+    public static EventDetail of(Event event, int boothCount, boolean isUserManager) {
+        return new EventDetail(
+                event.getId(),
+                event.getName(),
+                event.getMainImageUrl(),
+                event.getLocation(),
+                event.getDescription(),
+                getFormattingDate(event.getOpenDate().atStartOfDay()),
+                getFormattingDate(event.getCloseDate().atStartOfDay()),
+                convertJsonToList(event.getLayout().getImageUrl()),
+                boothCount,
+                isUserManager
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -60,6 +60,10 @@ public class UserBoothService {
         }
     }
 
+    public int getBoothCountByLinkedEvent(Event event) {
+        return boothRepository.countByLinkedEvent(event);
+    }
+
     private void dateTimePeriodCheck(LocalDateTime open, LocalDateTime close, Event event){
         LocalTime openTime = open.toLocalTime();
         LocalTime closeTime = close.toLocalTime();

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventLayoutService.java
@@ -1,5 +1,7 @@
 package com.openbook.openbook.basicuser.service;
 
+import static com.openbook.openbook.global.util.JsonService.convertJsonToList;
+
 import com.google.gson.Gson;
 import com.nimbusds.jose.shaded.gson.reflect.TypeToken;
 import com.openbook.openbook.basicuser.dto.EventLayoutCreateData;
@@ -45,10 +47,7 @@ public class UserEventLayoutService {
 
     public EventLayoutStatus getLayoutStatus(EventLayout eventLayout) {
         Map<String, List<LayoutAreaStatusData>> areas = layoutAreaService.getAreaStatus(eventLayout);
-        Gson gson = new Gson();
-        Type type = new TypeToken<ArrayList<String>>(){}.getType();
-        ArrayList<String> imageUrlList = gson.fromJson(eventLayout.getImageUrl(), type);
-        return new EventLayoutStatus(imageUrlList, eventLayout.getType(), areas);
+        return new EventLayoutStatus(convertJsonToList(eventLayout.getImageUrl()), eventLayout.getType(), areas);
     }
 
     private List<String> getImageUrlList(List<MultipartFile> layoutImages) {

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -5,6 +5,7 @@ import com.openbook.openbook.basicuser.dto.request.EventRegistrationRequest;
 import com.openbook.openbook.basicuser.dto.EventLayoutCreateData;
 import com.openbook.openbook.basicuser.dto.LayoutAreaCreateData;
 import com.openbook.openbook.basicuser.dto.response.EventBasicData;
+import com.openbook.openbook.basicuser.dto.response.EventDetail;
 import com.openbook.openbook.basicuser.dto.response.EventLayoutStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayout;
@@ -15,6 +16,7 @@ import com.openbook.openbook.user.repository.UserRepository;
 import com.openbook.openbook.user.entity.User;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,7 @@ public class UserEventService {
     private final UserRepository userRepository;
     private final EventRepository eventRepository;
     private final UserEventLayoutService userEventLayoutService;
+    private final UserBoothService userBoothService;
     private final S3Service s3Service;
 
     @Transactional
@@ -72,6 +75,13 @@ public class UserEventService {
             default -> throw new OpenBookException(HttpStatus.BAD_REQUEST, "요청 값이 잘못되었습니다.");
         };
         return events.map(EventBasicData::of);
+    }
+
+    @Transactional(readOnly = true)
+    public EventDetail getEventDetail(final Long userId, final Long eventId) {
+        Event event = getEventOrException(eventId);
+        int boothCount = userBoothService.getBoothCountByLinkedEvent(event);
+        return EventDetail.of(event, boothCount, Objects.equals(event.getManager().getId(), userId));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.booth.repository;
 
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.event.entity.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,7 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     @Query(value = "SELECT b FROM Booth b where b.linkedEvent.id =:eventId and b.status =:boothStatus ORDER BY b.registeredAt")
     Page<Booth> findAllBoothByEventIdAndStatus(Pageable pageable, Long eventId, BoothStatus boothStatus);
+
+    int countByLinkedEvent(Event linkedEvent);
+
 }

--- a/src/main/java/com/openbook/openbook/global/util/JsonService.java
+++ b/src/main/java/com/openbook/openbook/global/util/JsonService.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.global.util;
+
+import com.google.gson.Gson;
+import com.nimbusds.jose.shaded.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JsonService {
+    public static List<String> convertJsonToList(String jsonString) {
+        Gson gson = new Gson();
+        Type type = new TypeToken<ArrayList<String>>(){}.getType();
+        return gson.fromJson(jsonString, type);
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #38 

**GET /events/{event-id}**
행사 단 건을 조회하는 기능을 개발합니다.
응답 데이터는 다음 피그마 화면을 참고했습니다.
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/c269303e-1a7d-43bb-bd1a-c284ab902c20)


## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- JsonService에 convertJsonToList라는 전역 메서드를 만들었습니다.
이에 따라 기존 UserEventLayoutService의 json을 list로 변경하는 코드를 위 메서드를 사용하도록 리팩터링 했습니다.


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
GET /events/{event-id} 로 테스트 가능합니다.
- 조회 성공시
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/295835c5-ee43-4ce4-a8d5-9b7f38637799)
- 현재 로그인된 유저가 행사 매니저인 경우
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/4a82472a-15d9-42c7-b4f7-aab49885d4e4)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 금일 가능 부스 수는 저희가 현재 부스 등록을 날짜별로 나누고 있지 않기 때문에 제외했습니다!
- 궁금한 점, 조언 등 편하게 의견 주세요!😃
