### PR TITLE
Feat: 부스 상세 정보 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/UserBoothController.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.basicuser.controller;
 
 import com.openbook.openbook.basicuser.dto.request.BoothRegistrationRequest;
 import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
+import com.openbook.openbook.basicuser.dto.response.BoothDetail;
 import com.openbook.openbook.basicuser.service.UserBoothService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
@@ -12,10 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,5 +34,10 @@ public class UserBoothController {
     @GetMapping
     public ResponseEntity<SliceResponse<BoothBasicData>> getBooths(@PageableDefault(size = 6)Pageable pageable){
         return ResponseEntity.ok(SliceResponse.of(userBoothService.getBoothBasicData(pageable)));
+    }
+
+    @GetMapping("/{boothId}")
+    public ResponseEntity<BoothDetail> getBooth(@PathVariable Long boothId){
+        return ResponseEntity.ok(userBoothService.getBoothDetail(boothId));
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -10,6 +10,7 @@ public record BoothDetail(
         String name,
         String openDate,
         String closeDate,
+        String description,
         String mainImageUrl
 ) {
     public static BoothDetail of(Booth booth, Event event){
@@ -18,6 +19,7 @@ public record BoothDetail(
                 booth.getName(),
                 getFormattingDate(event.getOpenDate().atStartOfDay()),
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
+                booth.getDescription(),
                 booth.getMainImageUrl()
         );
     }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -1,0 +1,24 @@
+package com.openbook.openbook.basicuser.dto.response;
+
+import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.event.entity.Event;
+
+import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
+
+public record BoothDetail(
+        Long id,
+        String name,
+        String openDate,
+        String closeDate,
+        String mainImageUrl
+) {
+    public static BoothDetail of(Booth booth, Event event){
+        return new BoothDetail(
+                booth.getId(),
+                booth.getName(),
+                getFormattingDate(event.getOpenDate().atStartOfDay()),
+                getFormattingDate(event.getCloseDate().atStartOfDay()),
+                booth.getMainImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -78,7 +78,11 @@ public class UserBoothService {
     public BoothDetail getBoothDetail(Long boothId){
         Booth booth = getBoothOrException(boothId);
 
+        if(!booth.getStatus().equals(BoothStatus.APPROVE)){
+            throw new OpenBookException(HttpStatus.BAD_REQUEST, "승인 처리 된 부스가 아닙니다.");
+        }
         return BoothDetail.of(booth, booth.getLinkedEvent());
+
     }
 
     public int getBoothCountByLinkedEvent(Event event) {

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.basicuser.service;
 
 import com.openbook.openbook.basicuser.dto.request.BoothRegistrationRequest;
 import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
+import com.openbook.openbook.basicuser.dto.response.BoothDetail;
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.repository.BoothRepository;
@@ -73,6 +74,13 @@ public class UserBoothService {
         });
     }
 
+    @Transactional(readOnly = true)
+    public BoothDetail getBoothDetail(Long boothId){
+        Booth booth = getBoothOrException(boothId);
+
+        return BoothDetail.of(booth, booth.getLinkedEvent());
+    }
+
     public int getBoothCountByLinkedEvent(Event event) {
         return boothRepository.countByLinkedEvent(event);
     }
@@ -117,5 +125,10 @@ public class UserBoothService {
     private User getUserOrException(Long userId) {
         return userRepository.findById(userId).orElseThrow(() ->
                 new OpenBookException(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."));
+    }
+
+    private Booth getBoothOrException(Long boothId){
+        return boothRepository.findById(boothId).orElseThrow(() ->
+                new OpenBookException(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
@@ -1,6 +1,5 @@
 package com.openbook.openbook.booth.repository;
 
-import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.event.entity.Event;
@@ -24,6 +23,6 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     @Query("SELECT b FROM Booth b WHERE b.status=:boothStatus")
     Slice<Booth> findAllByStatus(BoothStatus boothStatus, Pageable pageable);
-
+    
     int countByLinkedEvent(Event linkedEvent);
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #46 
- 부스를 클릭했을 때 해당 부스에 대한 상세 정보를 나타내는 기능입니다

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- boothDetail 이라는 record 클래스를 만들어서 데이터 값을 응답하도록 했습니다.
- getBoothOrException 이라는 메서드를 추가해서 부스 객체를 리턴하도록 했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
<img width="973" alt="image" src="https://github.com/Project-OpenBook/openbook-server/assets/126096318/98396f8b-f275-4f2b-9d0e-bd54f15dbd23">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 우선 필수로 개발한 기능들을 바탕으로 부스 정보를 리턴했습니다. 즉, 공지사항 / 이벤트, 상품과 서비스 예약 정보와 같은 데이터들은 아직 넣지 않았고, 추후 개발하게 되면 추가하도록 하겠습니다!
- 개발하다가 생각해보게 된건, 부스 상세 정보를 볼 떄 approve된 부스 인지 확인하는 조건이 필요할 지에 대해 고민이 되었습니다! 의견 있으시면 말씀해 주세요!
