### PR TITLE
Fix: 부스 상세 정보 추가 및 시간 포멧팅

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -1,24 +1,30 @@
 package com.openbook.openbook.basicuser.dto.response;
 
 import com.openbook.openbook.booth.entity.Booth;
-import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.EventLayoutArea;
+import com.openbook.openbook.eventmanager.dto.BoothAreaData;
 
-import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.openbook.openbook.global.util.Formatter.getFormattingTime;
 
 public record BoothDetail(
         Long id,
         String name,
-        String openDate,
-        String closeDate,
+        String openTime,
+        String closeTime,
+        List<BoothAreaData> location,
         String description,
         String mainImageUrl
 ) {
-    public static BoothDetail of(Booth booth, Event event){
+    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreaData){
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
-                getFormattingDate(event.getOpenDate().atStartOfDay()),
-                getFormattingDate(event.getCloseDate().atStartOfDay()),
+                getFormattingTime(booth.getOpenTime()),
+                getFormattingTime(booth.getCloseTime()),
+                boothAreaData,
                 booth.getDescription(),
                 booth.getMainImageUrl()
         );

--- a/src/main/java/com/openbook/openbook/global/util/Formatter.java
+++ b/src/main/java/com/openbook/openbook/global/util/Formatter.java
@@ -9,4 +9,9 @@ public class Formatter {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
         return dateTime.format(formatter);
     }
+
+    public static String getFormattingTime(LocalDateTime dateTime){
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm:ss");
+        return dateTime.format(formatter);
+    }
 }

--- a/src/main/java/com/openbook/openbook/global/util/Formatter.java
+++ b/src/main/java/com/openbook/openbook/global/util/Formatter.java
@@ -11,7 +11,7 @@ public class Formatter {
     }
 
     public static String getFormattingTime(LocalDateTime dateTime){
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm:ss");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm");
         return dateTime.format(formatter);
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #52 
부스 상세 보기에 리턴될 데이터 값들을 추가 및 수정했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- boothDetail 클래스에 opendate와 closeDate 대신 openTime과 closeTime으로 변경
- 이때 시간은 이전에 날짜 포맷팅했던 것 처럼 시간 포맷팅 메서드를 만들어서 hh:mm:ss 포멧으로 리턴되도록 했습니다.
- 부스 위치 정보 추가
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 수정된 리턴 정보
<img width="1002" alt="image" src="https://github.com/Project-OpenBook/openbook-server/assets/126096318/8b748bea-f404-4725-8cd0-701f19cee619">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 날짜를 따로 포멧팅 한 것처럼 시간도 따로 포멧하는 메서드를 만들었습니다!
- 부스 위치 정보는 이전에 부스 신청 목록을 보일 때 부스의 위치를 보인 방식 대로 구현했습니다.
- 다른 의견이나 궁금하신 점 있으면 리뷰 남겨주세요!