### PR TITLE
Fix: 종료된 행사의 필터링 조건

### DIFF
--- a/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
@@ -33,7 +33,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             + "AND current_date BETWEEN e.boothRecruitmentStartDate AND e.boothRecruitmentEndDate")
     Slice<Event> findAllRecruiting(Pageable pageable);
 
-    @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' AND e.closeDate <= current_date")
+    @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE' AND e.closeDate < current_date")
     Slice<Event> findAllTerminated(Pageable pageable);
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #56 

m월 d일 까지 진행되는 행사도 m월 d일 당일에 종료된 행사 목록에 포함되는 문제를 해결했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
종료된 행사를 필터링하는 쿼리문을 수정했습니다.
- 전: `e.closeDate <= current_date"`
- 후: `e.closeDate < current_date"`


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
워크벤치에서 더미 데이터를 생성 후, 포스트맨으로 테스트하였습니다.
- /events?progress=terminated


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
궁금하신 점이나 의견 편하게 말씀해주세요 ! 😃