### PR TITLE
Fix: 일반 유저가 승인되지 않은 행사를 조회할 수 있는 문제

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -7,6 +7,7 @@ import com.openbook.openbook.basicuser.dto.LayoutAreaCreateData;
 import com.openbook.openbook.basicuser.dto.response.EventBasicData;
 import com.openbook.openbook.basicuser.dto.response.EventDetail;
 import com.openbook.openbook.basicuser.dto.response.EventLayoutStatus;
+import com.openbook.openbook.event.dto.EventStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayout;
 import com.openbook.openbook.event.repository.EventRepository;
@@ -80,6 +81,9 @@ public class UserEventService {
     @Transactional(readOnly = true)
     public EventDetail getEventDetail(final Long userId, final Long eventId) {
         Event event = getEventOrException(eventId);
+        if(!event.getStatus().equals(EventStatus.APPROVE)) {
+            throw new OpenBookException(HttpStatus.UNAUTHORIZED, "권한이 존재하지 않습니다.");
+        }
         int boothCount = userBoothService.getBoothCountByLinkedEvent(event);
         return EventDetail.of(event, boothCount, Objects.equals(event.getManager().getId(), userId));
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #51 

일반 유저가 승인되지 않은 행사의 정보를 조회할 수 있는 문제를 해결했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- UserEventService의 getEventDetail메서드에 조건을 추가
- 승인되지 않은 행사일 시, 권한 오류 반환

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 승인 된 행사를 조회할 경우
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/ba0451b2-7151-487e-9b1e-fa57d21f1f38)


- 승인 상태가 아닌 행사를 조회 할 경우
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/9081ce3e-235f-49bf-93c0-858920d018e9)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 전의 부스 상세조회에서는 해당 에러 메세지가 `HttpStatus.BAD_REQUEST, "승인 처리 된 부스가 아닙니다.`로 처리되었는데,
생각이 든 점이 관리자라면 상세 조회도 가능하다고 생각이 들어서 해당 오류는 권한이 없다고 봐도 되지 않을까? 하는 생각에
권한이 없다는 오류를 반환하도록 했습니다.  이에 대한 의견을 나눠보고 싶습니다!!
