### PR TITLE
Fix: 승인되지 않은 부스 조회시 에러 메세지 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -90,7 +90,7 @@ public class UserBoothService {
                 .collect(Collectors.toList());
 
         if(!booth.getStatus().equals(BoothStatus.APPROVE)){
-            throw new OpenBookException(HttpStatus.BAD_REQUEST, "권한이 존재하지 않습니다.");
+            throw new OpenBookException(HttpStatus.FORBIDDEN, "권한이 존재하지 않습니다.");
         }
         return BoothDetail.of(booth, boothAreaData);
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -90,7 +90,7 @@ public class UserBoothService {
                 .collect(Collectors.toList());
 
         if(!booth.getStatus().equals(BoothStatus.APPROVE)){
-            throw new OpenBookException(HttpStatus.BAD_REQUEST, "승인 처리 된 부스가 아닙니다.");
+            throw new OpenBookException(HttpStatus.BAD_REQUEST, "권한이 존재하지 않습니다.");
         }
         return BoothDetail.of(booth, boothAreaData);
 


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #62 
에러 메세지 수정
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
승인 되지 않은 부스를 조회했을 때 반환하는 에러 메세지를 수정했습니다.
"승인 처리 된 부스가 아닙니다" 에서 "권한이 존재하지 않습니다." 로 수정했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
추가 건의 사항 있으면 말씀해주세요 😊