### PR TITLE
Fix: 알림 테이블 구성

### DIFF
--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -7,16 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AlarmType {
 
-    //EVENT
-    EVENT_REQUEST_RECEIVED("행사 등록 요청이 들어왔습니다."),
-    EVENT_REQUEST_APPROVE("행사 등록 요청이 승인되었습니다."),
-    EVENT_REQUEST_REJECT("행사 등록 요청이 거부되었습니다."),
-
-    //BOOTH
-    BOOTH_REQUEST_RECEIVED("부스 등록 요청이 들어왔습니다."),
-    BOOTH_REQUEST_APPROVE("부스 등록 요청이 승인되었습니다."),
-    BOOTH_REQUEST_REJECT("부스 등록 요청이 거부되었습니다.");
-
+    EVENT("행사"),
+    BOOTH("부스");
 
     private final String description;
 }

--- a/src/main/java/com/openbook/openbook/user/entity/Alarm.java
+++ b/src/main/java/com/openbook/openbook/user/entity/Alarm.java
@@ -32,10 +32,16 @@ public class Alarm extends EntityBasicTime {
     @Enumerated(EnumType.STRING)
     private AlarmType type;
 
+    private String content;
+
+    private String message;
+
     @Builder
-    public Alarm(User receiver, User sender, AlarmType type) {
+    public Alarm(User receiver, User sender, AlarmType type, String content, String message) {
         this.receiver = receiver;
         this.sender = sender;
         this.type = type;
+        this.content = content;
+        this.message = message;
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #71 

알림 엔티티 구성을 변경했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
알림 엔티티에 다음 필드를 추가했습니다.
- content
- message

**예상 형태**
- [Type] content message

**예시**
- [행사] 벛꽃축제 신청이 승인되었습니다.
- [부스] 돌려돌려 돌림판 신청이 반려되었습니다.
- [관심 행사]  동동제 에 새로운 공지사항이 올라왔습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 워크벤치에서 확인
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/cabfd071-90a9-481c-88dd-697545981ebe)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- AlarmType 관련해서 의견을 구하고 싶습니다!!
유저가 행사를 승인 요청을 보낼 경우 요청된 행사에 대해 알림이 가고, 
관리자가 이를 승인하면 해당 유저에게 알림이 가게 될텐데
이 두 경우의 타입을 [행사]로 묶는게 좋을지 아니면 [등록 요청], [요청 답변] 이런식으로 나누는 것이 좋을지 
해당 건 관련해 의견을 듣고 싶습니다! (추후 구현에 참고하겠습니다!!)
- 구성에 관련해 다른 좋은 의견 생각나시는 거 말씀해주시면 반영하겠습니다!