### PR TITLE
Feat: 부스 태그 등록

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
@@ -15,6 +15,7 @@ public record BoothRegistrationRequest(
         @NotNull MultipartFile mainImage,
         @NotNull @Size(min = 1, max = 3) List<Long> layoutAreas,
         @NotBlank String description,
+        String boothTag,
         String accountBankName,
         String accountNumber
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -7,8 +7,10 @@ import com.openbook.openbook.basicuser.dto.response.BoothBasicData;
 import com.openbook.openbook.basicuser.dto.response.BoothDetail;
 import com.openbook.openbook.booth.dto.BoothDTO;
 import com.openbook.openbook.booth.dto.BoothStatus;
+import com.openbook.openbook.booth.dto.BoothTagDTO;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.service.BoothService;
+import com.openbook.openbook.booth.service.BoothTagService;
 import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayoutArea;
@@ -27,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +39,7 @@ import java.util.stream.Collectors;
 public class UserBoothService {
 
     private final BoothService boothService;
+    private final BoothTagService boothTagService;
     private final EventService eventService;
     private final LayoutAreaService layoutAreaService;
     private final UserService userService;
@@ -45,8 +49,8 @@ public class UserBoothService {
     public void boothRegistration(Long userId, BoothRegistrationRequest request){
         User user = userService.getUserOrException(userId);
         Event event = eventService.getEventOrException(request.linkedEvent());
-        LocalDateTime open = getDateTime(event.getOpenDate() + request.openTime());
-        LocalDateTime close = getDateTime(event.getCloseDate() + request.closeTime());
+        LocalDateTime open = getDateTime(event.getOpenDate() + " " + request.openTime());
+        LocalDateTime close = getDateTime(event.getCloseDate() + " " + request.closeTime());
         dateTimePeriodCheck(open, close, event);
         if(hasReservationData(request.layoutAreas())){
             throw new OpenBookException(ErrorCode.ALREADY_RESERVED_AREA);
@@ -62,8 +66,16 @@ public class UserBoothService {
                 .openTime(open)
                 .closeTime(close)
                 .build();
+
         Booth booth = boothService.createBooth(boothDTO);
         layoutAreaService.setBoothLocation(request.layoutAreas(), booth);
+
+        BoothTagDTO boothTagDTO = BoothTagDTO.builder()
+                .content(request.boothTag())
+                .booth(booth)
+                .build();
+
+        boothTagService.createBoothTag(boothTagDTO);
     }
 
 

--- a/src/main/java/com/openbook/openbook/booth/dto/BoothTagDTO.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/BoothTagDTO.java
@@ -1,0 +1,11 @@
+package com.openbook.openbook.booth.dto;
+
+import com.openbook.openbook.booth.entity.Booth;
+import lombok.Builder;
+
+@Builder
+public record BoothTagDTO(
+        String content,
+        Booth booth
+) {
+}

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
@@ -1,0 +1,9 @@
+package com.openbook.openbook.booth.repository;
+
+import com.openbook.openbook.booth.entity.BoothTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoothTagRepository extends JpaRepository<BoothTag, Long> {
+}

--- a/src/main/java/com/openbook/openbook/booth/service/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/BoothTagService.java
@@ -1,0 +1,22 @@
+package com.openbook.openbook.booth.service;
+
+import com.openbook.openbook.booth.dto.BoothTagDTO;
+import com.openbook.openbook.booth.entity.BoothTag;
+import com.openbook.openbook.booth.repository.BoothTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoothTagService {
+    private final BoothTagRepository boothTagRepository;
+
+    public BoothTag createBoothTag(BoothTagDTO boothTag){
+        return boothTagRepository.save(
+                BoothTag.builder()
+                        .content(boothTag.content())
+                        .booth(boothTag.booth())
+                        .build()
+            );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #64 
부스 등록시 해당 부스에 대한 태그 정보를 저장합니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothTagService와 BoothTagRepository, BoothTagDTO가 새로 생성 됐습니다.
- BoothRegistrationRequest에 boothTag 정보를 담을 수 있도록 추가했습니다.
- UserBoothService에서 boothTagDTO 안에 저장할 데이터를 넣고 BoothTagService에서 BoothTagRepository를 이용해 저장했습니다.
- 부스 오픈시간과 닫는 시간 관련해서 이전 리팩토링때 수정된 적 있었는데, Date와 Time 사이에는 빈 공간이 있어야 포멧 형식에 맞아 오류가 발생하지 않는 것을 확인했습니다! 이 점을 감안해서 다시 수정했습니다.
- 시간 포멧 관련 오류 참고 사이트: https://madini.tistory.com/27
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- postman에서 테스트
![스크린샷 2024-07-10 오전 12 16 57](https://github.com/Project-OpenBook/openbook-server/assets/126096318/2fdb9570-d456-47cc-80db-bd87f2097346)
- workbench에 저장된 boothTag데이터
![스크린샷 2024-07-10 오전 12 30 52](https://github.com/Project-OpenBook/openbook-server/assets/126096318/861b603e-2c47-4a33-bb50-6298bdc8c62c)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- BoothRegistrationRequest에 부스 태그를 입력 받을때 필수적으로 받아 올 지에 대해 고민이 되어 같이 의논하면 좋을 것 같습니다!
- 그 외에 필드명이나 기타 질문사항, 건의 사항 있으시면 말씀해주세요!