### PR TITLE
Feat: 알림 생성 기능

### DIFF
--- a/src/main/java/com/openbook/openbook/administrator/AdminEventService.java
+++ b/src/main/java/com/openbook/openbook/administrator/AdminEventService.java
@@ -8,6 +8,9 @@ import com.openbook.openbook.event.repository.EventRepository;
 import com.openbook.openbook.event.service.EventService;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.dto.AlarmType;
+import com.openbook.openbook.user.service.AlarmService;
+import com.openbook.openbook.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminEventService {
 
     private final EventService eventService;
+    private final AlarmService alarmService;
+    private final UserService userService;
 
     @Transactional(readOnly = true)
     public Page<AdminEventData> getRequestedEvents(Pageable pageable, String status) {
@@ -34,6 +39,8 @@ public class AdminEventService {
     public void changeEventStatus(Long eventId, EventStatus status) {
         Event event = eventService.getEventOrException(eventId);
         event.updateStatus(status);
+        AlarmType t = (status==EventStatus.APPROVE) ? AlarmType.EVENT_APPROVED : AlarmType.EVENT_REJECTED;
+        alarmService.createAlarm(userService.getAdminOrException(), event.getManager(), t, event.getName());
     }
 
     private EventStatus getEventStatus(String status) {

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -18,7 +18,9 @@ import com.openbook.openbook.eventmanager.dto.BoothAreaData;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.util.S3Service;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.dto.AlarmType;
 import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.AlarmService;
 import com.openbook.openbook.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +41,7 @@ public class UserBoothService {
     private final EventService eventService;
     private final LayoutAreaService layoutAreaService;
     private final UserService userService;
+    private final AlarmService alarmService;
     private final S3Service s3Service;
 
     @Transactional
@@ -64,6 +67,7 @@ public class UserBoothService {
                 .build();
         Booth booth = boothService.createBooth(boothDTO);
         layoutAreaService.setBoothLocation(request.layoutAreas(), booth);
+        alarmService.createAlarm(user, event.getManager(), AlarmType.BOOTH_REQUEST, booth.getName());
     }
 
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -16,7 +16,10 @@ import com.openbook.openbook.event.service.EventService;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.util.S3Service;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.dto.AlarmDTO;
+import com.openbook.openbook.user.dto.AlarmType;
 import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.AlarmService;
 import com.openbook.openbook.user.service.UserService;
 import java.time.LocalDate;
 import java.util.List;
@@ -39,6 +42,7 @@ public class UserEventService {
     private final EventService eventService;
     private final UserEventLayoutService userEventLayoutService;
     private final BoothService boothService;
+    private final AlarmService alarmService;
     private final S3Service s3Service;
 
     @Transactional
@@ -65,8 +69,8 @@ public class UserEventService {
                 .b_RecruitmentStartDate(request.boothRecruitmentStartDate())
                 .b_RecruitmentEndDate(request.boothRecruitmentEndDate())
                 .build();
-
         eventService.createEvent(event);
+        alarmService.createAlarm(user, userService.getAdminOrException(), AlarmType.EVENT_REQUEST, event.name());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -16,7 +16,6 @@ import com.openbook.openbook.event.service.EventService;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.util.S3Service;
 import com.openbook.openbook.global.exception.OpenBookException;
-import com.openbook.openbook.user.dto.AlarmDTO;
 import com.openbook.openbook.user.dto.AlarmType;
 import com.openbook.openbook.user.entity.User;
 import com.openbook.openbook.user.service.AlarmService;
@@ -26,13 +25,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
@@ -12,7 +12,9 @@ import com.openbook.openbook.eventmanager.dto.BoothAreaData;
 import com.openbook.openbook.eventmanager.dto.BoothManageData;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.dto.AlarmType;
 import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.AlarmService;
 import com.openbook.openbook.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,6 +33,7 @@ public class EventManagerService {
     private final EventService eventService;
     private final LayoutAreaService layoutAreaService;
     private final BoothService boothService;
+    private final AlarmService alarmService;
 
     @Transactional(readOnly = true)
     public Page<BoothManageData> getBoothManageData(String status, Long eventId, Pageable pageable, Long userId){
@@ -66,8 +69,10 @@ public class EventManagerService {
 
         if(boothStatus.equals(BoothStatus.APPROVE)){
             changeAreaStatus(eventLayoutAreas, EventLayoutAreaStatus.COMPLETE);
+            alarmService.createAlarm(user, booth.getManager(), AlarmType.BOOTH_APPROVED, booth.getName());
         } else if (boothStatus.equals(BoothStatus.REJECT)) {
             changeAreaStatus(eventLayoutAreas, EventLayoutAreaStatus.EMPTY);
+            alarmService.createAlarm(user, booth.getManager(), AlarmType.BOOTH_REJECTED, booth.getName());
         }
 
     }

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum AlarmType {
 
     EVENT("행사"),
+    EVENT_REQUEST("행사 등록이 요청되었습니다."),
     BOOTH("부스");
 
     private final String description;

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -7,10 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AlarmType {
 
-    EVENT("행사"),
     EVENT_REQUEST("행사 등록이 요청되었습니다."),
-    BOOTH("부스"),
-    BOOTH_REQUEST("부스 등록이 요청되었습니다.");
+    BOOTH_REQUEST("부스 등록이 요청되었습니다."),
+
     EVENT_APPROVED("행사 등록이 승인되었습니다."),
     EVENT_REJECTED("행사 등록이 거부되었습니다."),
 

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -14,7 +14,7 @@ public enum AlarmType {
     EVENT_REJECTED("행사 등록이 거부되었습니다."),
 
     BOOTH_APPROVED("부스 등록이 승인되었습니다."),
-    BOOTH_REJECTED("부스 등록이 거절되었습니다.")
+    BOOTH_REJECTED("부스 등록이 거부되었습니다.")
 
     ;
 

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -11,6 +11,10 @@ public enum AlarmType {
     EVENT_REQUEST("행사 등록이 요청되었습니다."),
     BOOTH("부스"),
     BOOTH_REQUEST("부스 등록이 요청되었습니다.");
+    BOOTH_APPROVED("부스 등록이 승인되었습니다."),
+    BOOTH_REJECTED("부스 등록이 거절되었습니다.")
+
+    ;
 
     private final String message;
 }

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -11,6 +11,9 @@ public enum AlarmType {
     EVENT_REQUEST("행사 등록이 요청되었습니다."),
     BOOTH("부스"),
     BOOTH_REQUEST("부스 등록이 요청되었습니다.");
+    EVENT_APPROVED("행사 등록이 승인되었습니다."),
+    EVENT_REJECTED("행사 등록이 거부되었습니다."),
+
     BOOTH_APPROVED("부스 등록이 승인되었습니다."),
     BOOTH_REJECTED("부스 등록이 거절되었습니다.")
 

--- a/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/user/dto/AlarmType.java
@@ -9,7 +9,8 @@ public enum AlarmType {
 
     EVENT("행사"),
     EVENT_REQUEST("행사 등록이 요청되었습니다."),
-    BOOTH("부스");
+    BOOTH("부스"),
+    BOOTH_REQUEST("부스 등록이 요청되었습니다.");
 
-    private final String description;
+    private final String message;
 }

--- a/src/main/java/com/openbook/openbook/user/entity/Alarm.java
+++ b/src/main/java/com/openbook/openbook/user/entity/Alarm.java
@@ -29,17 +29,18 @@ public class Alarm extends EntityBasicTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private User sender;
 
-    @Enumerated(EnumType.STRING)
-    private AlarmType alarmType;
+    private String alarmType;
 
     private String content;
 
+    private String message;
 
     @Builder
-    public Alarm(User receiver, User sender, AlarmType alarmType, String content) {
+    public Alarm(User receiver, User sender, String alarmType, String content, String message) {
         this.receiver = receiver;
         this.sender = sender;
         this.alarmType = alarmType;
         this.content = content;
+        this.message = message;
     }
 }

--- a/src/main/java/com/openbook/openbook/user/entity/Alarm.java
+++ b/src/main/java/com/openbook/openbook/user/entity/Alarm.java
@@ -30,18 +30,16 @@ public class Alarm extends EntityBasicTime {
     private User sender;
 
     @Enumerated(EnumType.STRING)
-    private AlarmType type;
+    private AlarmType alarmType;
 
     private String content;
 
-    private String message;
 
     @Builder
-    public Alarm(User receiver, User sender, AlarmType type, String content, String message) {
+    public Alarm(User receiver, User sender, AlarmType alarmType, String content) {
         this.receiver = receiver;
         this.sender = sender;
-        this.type = type;
+        this.alarmType = alarmType;
         this.content = content;
-        this.message = message;
     }
 }

--- a/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
+++ b/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
@@ -1,0 +1,10 @@
+package com.openbook.openbook.user.repository;
+
+
+import com.openbook.openbook.user.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+}

--- a/src/main/java/com/openbook/openbook/user/repository/UserRepository.java
+++ b/src/main/java/com/openbook/openbook/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.user.repository;
 
 
+import com.openbook.openbook.user.dto.UserRole;
 import com.openbook.openbook.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(Long id);
     Optional<User> findByEmail(String email);
+    Optional<User> findByRole(UserRole role);
 }

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -20,8 +20,9 @@ public class AlarmService {
                 Alarm.builder()
                         .sender(sender)
                         .receiver(receiver)
-                        .alarmType(type)
+                        .alarmType(type.toString())
                         .content(content)
+                        .message(type.getMessage())
                         .build()
         );
     }

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -1,0 +1,28 @@
+package com.openbook.openbook.user.service;
+
+
+import com.openbook.openbook.user.dto.AlarmDTO;
+import com.openbook.openbook.user.dto.AlarmType;
+import com.openbook.openbook.user.entity.Alarm;
+import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.repository.AlarmRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final AlarmRepository alarmRepository;
+
+    public void createAlarm(User sender, User receiver, AlarmType type, String content) {
+        alarmRepository.save(
+                Alarm.builder()
+                        .sender(sender)
+                        .receiver(receiver)
+                        .alarmType(type)
+                        .content(content)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -1,7 +1,6 @@
 package com.openbook.openbook.user.service;
 
 
-import com.openbook.openbook.user.dto.AlarmDTO;
 import com.openbook.openbook.user.dto.AlarmType;
 import com.openbook.openbook.user.entity.Alarm;
 import com.openbook.openbook.user.entity.User;

--- a/src/main/java/com/openbook/openbook/user/service/UserService.java
+++ b/src/main/java/com/openbook/openbook/user/service/UserService.java
@@ -22,6 +22,12 @@ public class UserService {
         );
     }
 
+    public User getAdminOrException() {
+        return userRepository.findByRole(UserRole.ADMIN).orElseThrow(() ->
+                new OpenBookException(ErrorCode.USER_NOT_FOUND)
+        );
+    }
+
     public Optional<User> getUserByEmail(final String email) {
         return userRepository.findByEmail(email);
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #73 

동작에 따라 알림이 보내지도록 기능을 개발했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 알림 테이블 구성 (엔티티)가 수정 
  - AlarmType의 Enum형태의 테이블을 String 형태로 변경하였습니다.
- 알람 서비스, 레포지토리 클래스 생성
- 유저 서비스에 관리자를 가져오는 getAdminOrException() 메서드 생성
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 각 api (행사 요청, 부스 요청, 승인 및 거절) 를 실행,
실행함에 따라 워크벤치에 값이 생성되는 것을 확인 가능
![image](https://github.com/Project-OpenBook/openbook-server/assets/105481797/07b4bf2a-4254-474a-a777-d39acfad282b)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 알림 타입 안의 메세지를 행사가 승인되었습니다, 부스가 승인되었습니다
처럼 행사나 부스라는 주어를 붙이고 있는데 컨텐츠에 명칭이 들어가니까 빼는 편이 좋을까요? 해당 의견도 듣고 싶습니다 !
- 궁금한 점이나 제안할 점 등등 편하게 의견 주세요 ! 👍