### PR TITLE
Feat: 알림 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
@@ -1,14 +1,20 @@
 package com.openbook.openbook.basicuser.controller;
 
 
+import com.openbook.openbook.basicuser.dto.response.AlarmData;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.basicuser.service.BasicUserService;
 import com.openbook.openbook.basicuser.dto.request.LoginRequest;
 import com.openbook.openbook.basicuser.dto.request.SignUpRequest;
+import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,4 +37,13 @@ public class BasicUserController {
         return ResponseEntity.ok(Map.of("token", token));
     }
 
+    @GetMapping("/alarms")
+    public ResponseEntity<SliceResponse<AlarmData>> alarmList(@PageableDefault(size = 5) Pageable pageable,
+                                                              Authentication authentication) {
+        return ResponseEntity.ok(
+                SliceResponse.of(
+                        basicUserService.getAlarm(pageable, Long.valueOf(authentication.getName()))
+                )
+        );
+    }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
@@ -38,11 +38,11 @@ public class BasicUserController {
     }
 
     @GetMapping("/alarms")
-    public ResponseEntity<SliceResponse<AlarmData>> alarmList(@PageableDefault(size = 5) Pageable pageable,
+    public ResponseEntity<SliceResponse<AlarmData>> getAlarms(@PageableDefault(size = 5) Pageable pageable,
                                                               Authentication authentication) {
         return ResponseEntity.ok(
                 SliceResponse.of(
-                        basicUserService.getAlarm(pageable, Long.valueOf(authentication.getName()))
+                        basicUserService.getAlarmData(pageable, Long.valueOf(authentication.getName()))
                 )
         );
     }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/AlarmData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/AlarmData.java
@@ -1,0 +1,22 @@
+package com.openbook.openbook.basicuser.dto.response;
+
+import com.openbook.openbook.user.dto.UserPublicData;
+import com.openbook.openbook.user.entity.Alarm;
+
+public record AlarmData(
+        Long id,
+        String type,
+        String content_name,
+        String message,
+        UserPublicData sender
+) {
+    public static AlarmData of(Alarm alarm){
+        return new AlarmData(
+                alarm.getId(),
+                alarm.getAlarmType(),
+                alarm.getContent(),
+                alarm.getMessage(),
+                UserPublicData.of(alarm.getSender())
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/AlarmData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/AlarmData.java
@@ -2,13 +2,15 @@ package com.openbook.openbook.basicuser.dto.response;
 
 import com.openbook.openbook.user.dto.UserPublicData;
 import com.openbook.openbook.user.entity.Alarm;
+import java.time.LocalDateTime;
 
 public record AlarmData(
         Long id,
         String type,
         String content_name,
         String message,
-        UserPublicData sender
+        UserPublicData sender,
+        LocalDateTime registeredAt
 ) {
     public static AlarmData of(Alarm alarm){
         return new AlarmData(
@@ -16,7 +18,8 @@ public record AlarmData(
                 alarm.getAlarmType(),
                 alarm.getContent(),
                 alarm.getMessage(),
-                UserPublicData.of(alarm.getSender())
+                UserPublicData.of(alarm.getSender()),
+                alarm.getRegisteredAt()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
@@ -52,7 +52,7 @@ public class BasicUserService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<AlarmData> getAlarm(Pageable pageable, final Long id) {
+    public Slice<AlarmData> getAlarmData(Pageable pageable, final Long id) {
         User user = userService.getUserOrException(id);
         return alarmService.getUserReceivedAlarm(pageable, user).map(AlarmData::of);
     }

--- a/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.basicuser.service;
 
 
+import com.openbook.openbook.basicuser.dto.response.AlarmData;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.util.JwtUtils;
 import com.openbook.openbook.global.exception.OpenBookException;
@@ -8,8 +9,11 @@ import com.openbook.openbook.user.dto.UserDTO;
 import com.openbook.openbook.basicuser.dto.request.LoginRequest;
 import com.openbook.openbook.basicuser.dto.request.SignUpRequest;
 import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.AlarmService;
 import com.openbook.openbook.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +25,7 @@ public class BasicUserService {
     private final JwtUtils jwtUtils;
     private final PasswordEncoder encoder;
     private final UserService userService;
+    private final AlarmService alarmService;
 
     @Transactional
     public void signup(final SignUpRequest request) {
@@ -45,4 +50,11 @@ public class BasicUserService {
         }
         return jwtUtils.generateToken(user.getId());
     }
+
+    @Transactional(readOnly = true)
+    public Slice<AlarmData> getAlarm(Pageable pageable, final Long id) {
+        User user = userService.getUserOrException(id);
+        return alarmService.getUserReceivedAlarm(pageable, user).map(AlarmData::of);
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/user/dto/UserPublicData.java
+++ b/src/main/java/com/openbook/openbook/user/dto/UserPublicData.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.user.dto;
+
+import com.openbook.openbook.user.entity.User;
+
+public record UserPublicData(
+        Long id,
+        String nickname
+) {
+    public static UserPublicData of(User user) {
+        return new UserPublicData(
+                user.getId(),
+                user.getNickname()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
+++ b/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
@@ -2,9 +2,14 @@ package com.openbook.openbook.user.repository;
 
 
 import com.openbook.openbook.user.entity.Alarm;
+import com.openbook.openbook.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    Slice<Alarm> findAllByReceiver(Pageable pageable, User receiver);
+
 }

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -6,7 +6,10 @@ import com.openbook.openbook.user.entity.Alarm;
 import com.openbook.openbook.user.entity.User;
 import com.openbook.openbook.user.repository.AlarmRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +27,9 @@ public class AlarmService {
                         .message(type.getMessage())
                         .build()
         );
+    }
+
+    public Slice<Alarm> getUserReceivedAlarm(Pageable pageable, User receiver) {
+        return alarmRepository.findAllByReceiver(pageable, receiver);
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #79 

**GET /alarms**

받은 알림을 조회하는 API 개발
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 해당 api의 컨트롤러는 basicuserController에 배치했습니다.
- 유저의 기본 정보를 담을 **UserPublicData** dto를 생성했습니다. 다음 정보가 포함됩니다.
  - 유저 id
  - 유저 nickname
- 알림 정보를 담을 **AlarmData** dto를 생성했습니다. 

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**GET /alarms** 요청으로 테스트 할 수 있습니다.

- 오래된 알림 조회 (기본 또는 sort=registeredAt,ASC)
![image](https://github.com/user-attachments/assets/22e6f05f-e909-40fb-8075-0864d3665f37)

- 최근 생긴 알림부터 조회 (sort=registeredAt,DESC)
![image](https://github.com/user-attachments/assets/6a4bdae8-eb5a-41a9-b129-c48b9a0631e4)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 앞으로 기본적인 유저 데이터를 포함할 때 UserPublicData 를 사용하면 좋을 것 같습니다!  
일단은 id와 닉네임만 public으로 넣었는데, 다른 정보 중 public으로 분류해도 괜찮을 것 같은 건
프론트 분들을 포함해서 상의해보고 추가하면 좋을 것 같습니다 !
- 궁금한 점이나 개선할 점 등 편하게 의견 주세요 !! 😃