### PR TITLE
Fix: 부스 상세에 행사 이름 추가

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothBasicData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothBasicData.java
@@ -8,6 +8,7 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
 public record BoothBasicData(
         Long id,
         String name,
+        String eventName,
         String openDate,
         String closeDate,
         String mainImageUrl
@@ -16,6 +17,7 @@ public record BoothBasicData(
         return new BoothBasicData(
                 booth.getId(),
                 booth.getName(),
+                event.getName(),
                 getFormattingDate(event.getOpenDate().atStartOfDay()),
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
                 booth.getMainImageUrl()

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -1,10 +1,8 @@
 package com.openbook.openbook.basicuser.dto.response;
 
 import com.openbook.openbook.booth.entity.Booth;
-import com.openbook.openbook.event.entity.EventLayoutArea;
 import com.openbook.openbook.eventmanager.dto.BoothAreaData;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.openbook.openbook.global.util.Formatter.getFormattingTime;

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -12,6 +12,7 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingTime;
 public record BoothDetail(
         Long id,
         String name,
+        String eventName,
         String openTime,
         String closeTime,
         List<BoothAreaData> location,
@@ -22,6 +23,7 @@ public record BoothDetail(
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
+                booth.getLinkedEvent().getName(),
                 getFormattingTime(booth.getOpenTime()),
                 getFormattingTime(booth.getCloseTime()),
                 boothAreaData,

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -12,6 +12,7 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingTime;
 public record BoothDetail(
         Long id,
         String name,
+        Long eventId,
         String eventName,
         String openTime,
         String closeTime,
@@ -23,6 +24,7 @@ public record BoothDetail(
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
+                booth.getLinkedEvent().getId(),
                 booth.getLinkedEvent().getName(),
                 getFormattingTime(booth.getOpenTime()),
                 getFormattingTime(booth.getCloseTime()),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #75

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- booth상세 보기 정보를 응답하는 dto에 행사 이름을 포함했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
![image](https://github.com/user-attachments/assets/df5d62f7-5c4e-47d3-9186-e2bcab410ba5)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
현재는 부스 상세보기를 했을 때 행사 정보가 뜨게 되어있는데 부스 둘러보기 할 때도 행사정보가 뜨는게 좋을 까요?! 의견 내주시면 감사하겠습니다!
질문사항이나 의견있으시면 말씀해주세요!