### PR TITLE
Feat: 알림 단건 삭제 API

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
@@ -14,7 +14,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +47,11 @@ public class BasicUserController {
                         basicUserService.getAlarmData(pageable, Long.valueOf(authentication.getName()))
                 )
         );
+    }
+
+    @DeleteMapping("/alarms/{alarmId}")
+    public ResponseEntity<ResponseMessage> deleteAlarm(Authentication authentication, @PathVariable Long alarmId) {
+        basicUserService.deleteAlarm(Long.valueOf(authentication.getName()), alarmId);
+        return ResponseEntity.ok(new ResponseMessage("알림을 삭제했습니다."));
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
@@ -8,6 +8,7 @@ import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.user.dto.UserDTO;
 import com.openbook.openbook.basicuser.dto.request.LoginRequest;
 import com.openbook.openbook.basicuser.dto.request.SignUpRequest;
+import com.openbook.openbook.user.entity.Alarm;
 import com.openbook.openbook.user.entity.User;
 import com.openbook.openbook.user.service.AlarmService;
 import com.openbook.openbook.user.service.UserService;
@@ -55,6 +56,15 @@ public class BasicUserService {
     public Slice<AlarmData> getAlarmData(Pageable pageable, final Long id) {
         User user = userService.getUserOrException(id);
         return alarmService.getUserReceivedAlarm(pageable, user).map(AlarmData::of);
+    }
+
+    @Transactional
+    public void deleteAlarm(final Long userId, final Long alarmId) {
+        Alarm alarm = alarmService.getAlarmOrException(alarmId);
+        if(alarm.getReceiver().getId()!=userId) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        alarmService.deleteAlarm(alarm);
     }
 
 }

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 정보를 찾을 수 없습니다."),
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
+    ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
 
     // INTERNET SERVER ERROR
     FIlE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.")

--- a/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
+++ b/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.user.repository;
 
 import com.openbook.openbook.user.entity.Alarm;
 import com.openbook.openbook.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+    Optional<Alarm> findById(Long id);
     Slice<Alarm> findAllByReceiver(Pageable pageable, User receiver);
 
 }

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -1,6 +1,8 @@
 package com.openbook.openbook.user.service;
 
 
+import com.openbook.openbook.global.exception.ErrorCode;
+import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.user.dto.AlarmType;
 import com.openbook.openbook.user.entity.Alarm;
 import com.openbook.openbook.user.entity.User;
@@ -17,6 +19,12 @@ public class AlarmService {
 
     private final AlarmRepository alarmRepository;
 
+    public Alarm getAlarmOrException(Long id) {
+        return alarmRepository.findById(id).orElseThrow(()->
+                new OpenBookException(ErrorCode.ALARM_NOT_FOUND)
+        );
+    }
+
     public void createAlarm(User sender, User receiver, AlarmType type, String content) {
         alarmRepository.save(
                 Alarm.builder()
@@ -31,5 +39,9 @@ public class AlarmService {
 
     public Slice<Alarm> getUserReceivedAlarm(Pageable pageable, User receiver) {
         return alarmRepository.findAllByReceiver(pageable, receiver);
+    }
+
+    public void deleteAlarm(Alarm alarm) {
+        alarmRepository.delete(alarm);
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #84 

받은 알림 단 건을 삭제하는 API 개발

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- id로 알림 찾는 메서드 추가
- 알림이 없는 경우의 에러코드 추가
- 알림 삭제 기능 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**DELETE /alarms/:id** 요청으로 확인 가능합니다.
- 성공했을 경우 (200)
![image](https://github.com/user-attachments/assets/52490ec2-c265-4367-8489-1d56908d7e5e)
- 현재 로그인한 유저의 알림이 아닌 경우 (403)
![image](https://github.com/user-attachments/assets/033341fc-ef8e-4040-bd6f-119d218ab7e6)
- 일치하는 알림 id가 없는 경우 (404)
![image](https://github.com/user-attachments/assets/33571389-b467-4a33-8106-044d47905b2a)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금한 점이나 개선할 점 등 의견 있으시면 편하게 주세요! 😃