### PR TITLE
Fix: 부스 태그 데이터 리스트 형식으로 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/request/BoothRegistrationRequest.java
@@ -15,7 +15,7 @@ public record BoothRegistrationRequest(
         @NotNull MultipartFile mainImage,
         @NotNull @Size(min = 1, max = 3) List<Long> layoutAreas,
         @NotBlank String description,
-        String boothTag,
+        @Size(max = 5) List<String> boothTag,
         String accountBankName,
         String accountNumber
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -9,6 +9,7 @@ import com.openbook.openbook.booth.dto.BoothDTO;
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.dto.BoothTagDTO;
 import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.BoothTag;
 import com.openbook.openbook.booth.service.BoothService;
 import com.openbook.openbook.booth.service.BoothTagService;
 import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
@@ -72,13 +73,16 @@ public class UserBoothService {
 
         Booth booth = boothService.createBooth(boothDTO);
         layoutAreaService.setBoothLocation(request.layoutAreas(), booth);
-        BoothTagDTO boothTagDTO = BoothTagDTO.builder()
-                .content(request.boothTag())
-                .booth(booth)
-                .build();
 
-        boothTagService.createBoothTag(boothTagDTO);
-      
+        for(String boothTag : request.boothTag()){
+            BoothTagDTO boothTagDTO = BoothTagDTO.builder()
+                    .content(boothTag)
+                    .booth(booth)
+                    .build();
+
+            boothTagService.createBoothTag(boothTagDTO);
+        }
+
         alarmService.createAlarm(user, event.getManager(), AlarmType.BOOTH_REQUEST, booth.getName());
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -74,6 +74,10 @@ public class UserBoothService {
         Booth booth = boothService.createBooth(boothDTO);
         layoutAreaService.setBoothLocation(request.layoutAreas(), booth);
 
+        if(request.boothTag().size() != request.boothTag().stream().distinct().count()){
+            throw new OpenBookException(ErrorCode.ALREADY_TAG_DATA);
+        }
+
         for(String boothTag : request.boothTag()){
             BoothTagDTO boothTagDTO = BoothTagDTO.builder()
                     .content(boothTag)

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     ALREADY_RESERVED_AREA(HttpStatus.CONFLICT, "선택 가능한 구역이 아닙니다."),
     INVALID_DATE_RANGE(HttpStatus.CONFLICT, "입력된 날짜 범위가 유효하지 않습니다."),
     INVALID_LAYOUT_ENTRY(HttpStatus.CONFLICT, "입력된 배치도 형식에 오류가 있습니다."),
+    ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
 
     // NOT FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #86 

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스 태그 데이터를 여러 개 받을 수 있도록 list형식으로 변경했습니다.
- Size 어노테이션을 추가해서 최대 5개까지 입력 받을 수 있게 제한을 주었습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 오락, 가족이라는 태그를 추가
![image](https://github.com/user-attachments/assets/fd2e7d33-fc9d-4d7f-b9aa-d9a01b841b96)
- db에 저장
![image](https://github.com/user-attachments/assets/8c653099-190c-4d74-865c-761deb36beae)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
질문사항이나 이외 추가 의견있으시면 말씀해주세요!