### PR TITLE
Fix: 부스와 행사 태그 필드명 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/entity/BoothTag.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothTag.java
@@ -13,14 +13,14 @@ public class BoothTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String content;
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Booth booth;
 
     @Builder
-    public BoothTag(String content, Booth booth){
-        this.content = content;
+    public BoothTag(String name, Booth booth){
+        this.name = name;
         this.booth = booth;
     }
 

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
@@ -12,6 +12,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoothTagRepository extends JpaRepository<BoothTag, Long> {
 
-    @Query("SELECT bt.booth FROM BoothTag bt WHERE bt.content LIKE :content")
-    Slice<Booth> findBoothByContent(Pageable pageable, @Param(value = "content") String content);
+    @Query("SELECT bt.booth FROM BoothTag bt WHERE bt.name LIKE :name")
+    Slice<Booth> findBoothByName(Pageable pageable, @Param(value = "name") String name);
 }

--- a/src/main/java/com/openbook/openbook/booth/service/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/BoothTagService.java
@@ -17,13 +17,13 @@ public class BoothTagService {
     public BoothTag createBoothTag(BoothTagDTO boothTag){
         return boothTagRepository.save(
                 BoothTag.builder()
-                        .content(boothTag.content())
+                        .name(boothTag.content())
                         .booth(boothTag.booth())
                         .build()
             );
     }
 
     public Slice<Booth> getBoothByTag(Pageable pageable, String boothTag){
-        return boothTagRepository.findBoothByContent(pageable, boothTag);
+        return boothTagRepository.findBoothByName(pageable, boothTag);
     }
 }

--- a/src/main/java/com/openbook/openbook/event/entity/EventTag.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventTag.java
@@ -20,14 +20,14 @@ public class EventTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String content;
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Event linkedEvent;
 
     @Builder
-    public EventTag(String content, Event linkedEvent) {
-        this.content = content;
+    public EventTag(String name, Event linkedEvent) {
+        this.name = name;
         this.linkedEvent = linkedEvent;
     }
 }

--- a/src/main/java/com/openbook/openbook/event/service/EventTagService.java
+++ b/src/main/java/com/openbook/openbook/event/service/EventTagService.java
@@ -13,10 +13,10 @@ public class EventTagService {
 
     private final EventTagRepository eventTagRepository;
 
-    public void createEventTag(String content, Event event) {
+    public void createEventTag(String name, Event event) {
         eventTagRepository.save(
                 EventTag.builder()
-                        .content(content)
+                        .name(name)
                         .linkedEvent(event)
                         .build()
         );


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #94

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 행사 태그명을 content에서 name으로 수정했습니다.
- 부스 태그명을 content에서 name으로 수정했습니다.
- 행사와 부스 태그 등록할 때나 부스 태그 검색할 때 태그명이 활용된 부분은 name으로 수정했습니다.
- db 안 행사와 부스 태그 테이블에서의 관련 컬럼명도 name으로 수정했습니다.
- 추가적으로 부스 태그에 연결된 부스 필드명도 행사 필드명과 통일해서 booth에서 linked_booth로 수정했습니다. (db 외래키 컬럼명도 수정했습니다.)
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 프로젝트 작동 여부
- db 칼럼명 수정 결과
![image](https://github.com/user-attachments/assets/190bb01e-e781-45db-8237-1dd94bf67a81)
![image](https://github.com/user-attachments/assets/9ccf01ba-e857-4b43-b623-edd9509cee9a)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 기타 의견이나 질문 있으면 말씀해주세요!