### PR TITLE
Feat: 받은 알림 전체 삭제 API

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/BasicUserController.java
@@ -49,9 +49,16 @@ public class BasicUserController {
         );
     }
 
+    @DeleteMapping("/alarms")
+    public ResponseEntity<ResponseMessage> deleteAllAlarm(Authentication authentication) {
+        basicUserService.deleteAllAlarm(Long.valueOf(authentication.getName()));
+        return ResponseEntity.ok(new ResponseMessage("전체 알림을 삭제했습니다."));
+    }
+
     @DeleteMapping("/alarms/{alarmId}")
     public ResponseEntity<ResponseMessage> deleteAlarm(Authentication authentication, @PathVariable Long alarmId) {
         basicUserService.deleteAlarm(Long.valueOf(authentication.getName()), alarmId);
         return ResponseEntity.ok(new ResponseMessage("알림을 삭제했습니다."));
     }
+
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
@@ -70,6 +70,9 @@ public class BasicUserService {
     @Transactional
     public void deleteAllAlarm(final Long userId) {
         User user = userService.getUserOrException(userId);
+        if(!alarmService.userHasReceivedAlarms(userId)) {
+            throw new OpenBookException(ErrorCode.ALARM_NOT_FOUND);
+        }
         alarmService.deleteAllReceiverAlarm(user.getId());
     }
 

--- a/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/BasicUserService.java
@@ -67,4 +67,10 @@ public class BasicUserService {
         alarmService.deleteAlarm(alarm);
     }
 
+    @Transactional
+    public void deleteAllAlarm(final Long userId) {
+        User user = userService.getUserOrException(userId);
+        alarmService.deleteAllReceiverAlarm(user.getId());
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
+++ b/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
+    boolean existsByReceiverId(Long receiverId);
     Optional<Alarm> findById(Long id);
     Slice<Alarm> findAllByReceiver(Pageable pageable, User receiver);
     @Modifying

--- a/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
+++ b/src/main/java/com/openbook/openbook/user/repository/AlarmRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,5 +16,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Optional<Alarm> findById(Long id);
     Slice<Alarm> findAllByReceiver(Pageable pageable, User receiver);
+    @Modifying
+    @Query("DELETE FROM Alarm a WHERE a.receiver.id=:receiverId")
+    void deleteAllByReceiverId(Long receiverId);
 
 }

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -44,4 +44,8 @@ public class AlarmService {
     public void deleteAlarm(Alarm alarm) {
         alarmRepository.delete(alarm);
     }
+
+    public void deleteAllReceiverAlarm(Long id) {
+        alarmRepository.deleteAllByReceiverId(id);
+    }
 }

--- a/src/main/java/com/openbook/openbook/user/service/AlarmService.java
+++ b/src/main/java/com/openbook/openbook/user/service/AlarmService.java
@@ -19,6 +19,10 @@ public class AlarmService {
 
     private final AlarmRepository alarmRepository;
 
+    public boolean userHasReceivedAlarms(Long receiverId) {
+        return alarmRepository.existsByReceiverId(receiverId);
+    }
+
     public Alarm getAlarmOrException(Long id) {
         return alarmRepository.findById(id).orElseThrow(()->
                 new OpenBookException(ErrorCode.ALARM_NOT_FOUND)
@@ -45,7 +49,7 @@ public class AlarmService {
         alarmRepository.delete(alarm);
     }
 
-    public void deleteAllReceiverAlarm(Long id) {
-        alarmRepository.deleteAllByReceiverId(id);
+    public void deleteAllReceiverAlarm(Long receiverId) {
+        alarmRepository.deleteAllByReceiverId(receiverId);
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #98 

받은 전체 알림을 삭제하는 API를 개발했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 알람 전체 삭제 api 추가
- receiver 기준 알람 삭제 기능 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**DELETE /alarms** 요청으로 테스트 가능합니다.

- 성공시 (200)
![image](https://github.com/user-attachments/assets/460e7f23-2ba0-48b6-a957-35577bc115ef)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 삭제할 알림이 없을 때 해당 api를 호출해도 성공으로 반환되는데, 이 경우에 예외로 처리하는게 나을까요?
- 변수명 메서드명 등 조언이나 개선할 점, 궁금한 점 편하게 의견 주세요! 😃
