### PR TITLE
Fix: 행사와 부스 조회 결과에 태그 정보 추가

### DIFF
--- a/src/main/java/com/openbook/openbook/administrator/dto/AdminEventData.java
+++ b/src/main/java/com/openbook/openbook/administrator/dto/AdminEventData.java
@@ -4,8 +4,10 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
 
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.dto.EventStatus;
+import com.openbook.openbook.event.entity.EventTag;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import java.util.List;
 
 public record AdminEventData(
         Long id,
@@ -13,16 +15,18 @@ public record AdminEventData(
         String location,
         String registrationDate,
         String description,
+        List<String> tags,
         @Enumerated(EnumType.STRING)
         EventStatus status
 ) {
-    public static AdminEventData of(Event event) {
+    public static AdminEventData of(Event event, List<EventTag> tags) {
         return new AdminEventData(
                 event.getId(),
                 event.getName(),
                 event.getLocation(),
                 getFormattingDate(event.getRegisteredAt()),
                 event.getDescription(),
+                tags.stream().map(EventTag::getName).toList(),
                 event.getStatus()
         );
     }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothBasicData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothBasicData.java
@@ -1,7 +1,9 @@
 package com.openbook.openbook.basicuser.dto.response;
 
 import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.BoothTag;
 import com.openbook.openbook.event.entity.Event;
+import java.util.List;
 
 import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
 
@@ -11,16 +13,18 @@ public record BoothBasicData(
         String eventName,
         String openDate,
         String closeDate,
-        String mainImageUrl
+        String mainImageUrl,
+        List<String> tags
 ) {
-    public static BoothBasicData of(Booth booth, Event event){
+    public static BoothBasicData of(Booth booth, Event event, List<BoothTag> tags){
         return new BoothBasicData(
                 booth.getId(),
                 booth.getName(),
                 event.getName(),
                 getFormattingDate(event.getOpenDate().atStartOfDay()),
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
-                booth.getMainImageUrl()
+                booth.getMainImageUrl(),
+                tags.stream().map(BoothTag::getName).toList()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.basicuser.dto.response;
 
 import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.BoothTag;
 import com.openbook.openbook.eventmanager.dto.BoothAreaData;
 
 import java.util.List;
@@ -10,25 +11,27 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingTime;
 public record BoothDetail(
         Long id,
         String name,
-        Long eventId,
-        String eventName,
+        String description,
+        String mainImageUrl,
         String openTime,
         String closeTime,
         List<BoothAreaData> location,
-        String description,
-        String mainImageUrl
+        List<String> tags,
+        Long eventId,
+        String eventName
 ) {
-    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreaData){
+    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreas, List<BoothTag> tags){
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
-                booth.getLinkedEvent().getId(),
-                booth.getLinkedEvent().getName(),
+                booth.getDescription(),
+                booth.getMainImageUrl(),
                 getFormattingTime(booth.getOpenTime()),
                 getFormattingTime(booth.getCloseTime()),
-                boothAreaData,
-                booth.getDescription(),
-                booth.getMainImageUrl()
+                boothAreas,
+                tags.stream().map(BoothTag::getName).toList(),
+                booth.getLinkedEvent().getId(),
+                booth.getLinkedEvent().getName()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/EventBasicData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/EventBasicData.java
@@ -3,6 +3,8 @@ package com.openbook.openbook.basicuser.dto.response;
 import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
 
 import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.EventTag;
+import java.util.List;
 
 public record EventBasicData(
         Long id,
@@ -11,9 +13,10 @@ public record EventBasicData(
         String openDate,
         String closeDate,
         String recruitStartDate,
-        String recruitEndDate
+        String recruitEndDate,
+        List<String> tags
 ) {
-    public static EventBasicData of(Event event) {
+    public static EventBasicData of(Event event, List<String> tags) {
         return new EventBasicData(
                 event.getId(),
                 event.getName(),
@@ -21,7 +24,8 @@ public record EventBasicData(
                 getFormattingDate(event.getOpenDate().atStartOfDay()),
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
                 getFormattingDate(event.getBoothRecruitmentStartDate().atStartOfDay()),
-                getFormattingDate(event.getBoothRecruitmentEndDate().atStartOfDay())
+                getFormattingDate(event.getBoothRecruitmentEndDate().atStartOfDay()),
+                tags
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/EventBasicData.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/EventBasicData.java
@@ -16,7 +16,7 @@ public record EventBasicData(
         String recruitEndDate,
         List<String> tags
 ) {
-    public static EventBasicData of(Event event, List<String> tags) {
+    public static EventBasicData of(Event event, List<EventTag> tags) {
         return new EventBasicData(
                 event.getId(),
                 event.getName(),
@@ -25,7 +25,7 @@ public record EventBasicData(
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
                 getFormattingDate(event.getBoothRecruitmentStartDate().atStartOfDay()),
                 getFormattingDate(event.getBoothRecruitmentEndDate().atStartOfDay()),
-                tags
+                tags.stream().map(EventTag::getName).toList()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/EventDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/EventDetail.java
@@ -14,11 +14,12 @@ public record EventDetail(
         String description,
         String openDate,
         String closeDate,
+        List<String> tags,
         List<String> layoutImageUrls,
         int boothCount,
         boolean isUserManager
 ) {
-    public static EventDetail of(Event event, int boothCount, boolean isUserManager) {
+    public static EventDetail of(Event event, List<String> tags, int boothCount, boolean isUserManager) {
         return new EventDetail(
                 event.getId(),
                 event.getName(),
@@ -27,6 +28,7 @@ public record EventDetail(
                 event.getDescription(),
                 getFormattingDate(event.getOpenDate().atStartOfDay()),
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
+                tags,
                 convertJsonToList(event.getLayout().getImageUrl()),
                 boothCount,
                 isUserManager

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/EventDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/EventDetail.java
@@ -4,7 +4,9 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
 import static com.openbook.openbook.global.util.JsonService.convertJsonToList;
 
 import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.EventTag;
 import java.util.List;
+import java.util.Objects;
 
 public record EventDetail(
         Long id,
@@ -19,7 +21,7 @@ public record EventDetail(
         int boothCount,
         boolean isUserManager
 ) {
-    public static EventDetail of(Event event, List<String> tags, int boothCount, boolean isUserManager) {
+    public static EventDetail of(Event event, Long userId, List<EventTag> tags, int boothCount) {
         return new EventDetail(
                 event.getId(),
                 event.getName(),
@@ -28,10 +30,10 @@ public record EventDetail(
                 event.getDescription(),
                 getFormattingDate(event.getOpenDate().atStartOfDay()),
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
-                tags,
+                tags.stream().map(EventTag::getName).toList(),
                 convertJsonToList(event.getLayout().getImageUrl()),
                 boothCount,
-                isUserManager
+                Objects.equals(event.getManager().getId(), userId)
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -94,7 +94,8 @@ public class UserBoothService {
     @Transactional(readOnly = true)
     public Slice<BoothBasicData> getBoothBasicData(Pageable pageable) {
         return boothService.getBoothsByStatus(pageable, BoothStatus.APPROVE).map(
-                booth -> BoothBasicData.of(booth, booth.getLinkedEvent())
+                booth -> BoothBasicData.of(
+                        booth, booth.getLinkedEvent(), boothTagService.getBoothTag(booth.getId()))
         );
     }
 
@@ -108,12 +109,15 @@ public class UserBoothService {
                 .stream()
                 .map(BoothAreaData::of)
                 .collect(Collectors.toList());
-        return BoothDetail.of(booth, boothAreaData);
+        return BoothDetail.of(booth, boothAreaData, boothTagService.getBoothTag(booth.getId()));
     }
 
     @Transactional(readOnly = true)
     public Slice<BoothBasicData> searchByBoothTag(Pageable pageable, String boothTag){
-        return boothTagService.getBoothByTag(pageable, boothTag).map(booth -> BoothBasicData.of(booth, booth.getLinkedEvent()));
+        return boothTagService.getBoothByTag(pageable, boothTag).map(
+                booth -> BoothBasicData.of(
+                        booth, booth.getLinkedEvent(), boothTagService.getBoothTag(booth.getId()))
+        );
     }
 
     private boolean hasReservationData(List<Long> eventLayoutAreaList){

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -81,11 +81,7 @@ public class UserEventService {
     public Slice<EventBasicData> getEventBasicData(Pageable pageable, String eventProgress) {
         Slice<Event> events = eventService.getEventsWithProgress(pageable, eventProgress);
         return events.map(
-                event -> EventBasicData.of(
-                        event, eventTagService.getEventTags(event.getId())
-                                .stream()
-                                .map(EventTag::getName)
-                                .toList())
+                event -> EventBasicData.of(event, eventTagService.getEventTags(event.getId()))
         );
     }
 
@@ -95,9 +91,9 @@ public class UserEventService {
         if(!event.getStatus().equals(EventStatus.APPROVE)) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
-        List<String> tags = eventTagService.getEventTags(event.getId()).stream().map(EventTag::getName).toList();
+        List<EventTag> tags = eventTagService.getEventTags(event.getId());
         int boothCount = boothService.getBoothCountByEvent(event);
-        return EventDetail.of(event, tags, boothCount, Objects.equals(event.getManager().getId(), userId));
+        return EventDetail.of(event, userId, tags, boothCount);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserEventService.java
@@ -12,6 +12,7 @@ import com.openbook.openbook.event.dto.EventDTO;
 import com.openbook.openbook.event.dto.EventStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayout;
+import com.openbook.openbook.event.entity.EventTag;
 import com.openbook.openbook.event.service.EventService;
 import com.openbook.openbook.event.service.EventTagService;
 import com.openbook.openbook.global.exception.ErrorCode;
@@ -79,7 +80,13 @@ public class UserEventService {
     @Transactional(readOnly = true)
     public Slice<EventBasicData> getEventBasicData(Pageable pageable, String eventProgress) {
         Slice<Event> events = eventService.getEventsWithProgress(pageable, eventProgress);
-        return events.map(EventBasicData::of);
+        return events.map(
+                event -> EventBasicData.of(
+                        event, eventTagService.getEventTags(event.getId())
+                                .stream()
+                                .map(EventTag::getName)
+                                .toList())
+        );
     }
 
     @Transactional(readOnly = true)
@@ -88,8 +95,9 @@ public class UserEventService {
         if(!event.getStatus().equals(EventStatus.APPROVE)) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
+        List<String> tags = eventTagService.getEventTags(event.getId()).stream().map(EventTag::getName).toList();
         int boothCount = boothService.getBoothCountByEvent(event);
-        return EventDetail.of(event, boothCount, Objects.equals(event.getManager().getId(), userId));
+        return EventDetail.of(event, tags, boothCount, Objects.equals(event.getManager().getId(), userId));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/booth/entity/Booth.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/Booth.java
@@ -54,7 +54,7 @@ public class Booth extends EntityBasicTime {
     @Enumerated(EnumType.STRING)
     private BoothStatus status;
 
-    @OneToMany(mappedBy = "booth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "linkedBooth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<BoothTag> boothTags = new ArrayList<>();
 
     @Override

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothTag.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothTag.java
@@ -16,12 +16,12 @@ public class BoothTag {
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Booth booth;
+    private Booth linkedBooth;
 
     @Builder
     public BoothTag(String name, Booth booth){
         this.name = name;
-        this.booth = booth;
+        this.linkedBooth = booth;
     }
 
 }

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
@@ -2,6 +2,8 @@ package com.openbook.openbook.booth.repository;
 
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothTag;
+import com.openbook.openbook.event.entity.EventTag;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +14,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoothTagRepository extends JpaRepository<BoothTag, Long> {
 
-    @Query("SELECT bt.booth FROM BoothTag bt WHERE bt.name LIKE :name")
+    @Query("SELECT t FROM BoothTag t WHERE t.linkedBooth.id=:boothId")
+    List<BoothTag> findAllByLinkedBoothId(Long boothId);
+
+    @Query("SELECT bt.linkedBooth FROM BoothTag bt WHERE bt.name LIKE :name")
     Slice<Booth> findBoothByName(Pageable pageable, @Param(value = "name") String name);
+
 }

--- a/src/main/java/com/openbook/openbook/booth/service/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/BoothTagService.java
@@ -4,6 +4,7 @@ import com.openbook.openbook.booth.dto.BoothTagDTO;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothTag;
 import com.openbook.openbook.booth.repository.BoothTagRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,6 +22,10 @@ public class BoothTagService {
                         .booth(boothTag.booth())
                         .build()
             );
+    }
+
+    public List<BoothTag> getBoothTag(Long id){
+        return boothTagRepository.findAllByLinkedBoothId(id);
     }
 
     public Slice<Booth> getBoothByTag(Pageable pageable, String boothTag){

--- a/src/main/java/com/openbook/openbook/event/repository/EventTagRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventTagRepository.java
@@ -1,9 +1,14 @@
 package com.openbook.openbook.event.repository;
 
 import com.openbook.openbook.event.entity.EventTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EventTagRepository extends JpaRepository<EventTag, Long> {
+    @Query("SELECT t FROM EventTag t WHERE t.linkedEvent.id=:eventId")
+    List<EventTag> findAllByLinkedEventId(Long eventId);
+
 }

--- a/src/main/java/com/openbook/openbook/event/service/EventTagService.java
+++ b/src/main/java/com/openbook/openbook/event/service/EventTagService.java
@@ -4,6 +4,7 @@ package com.openbook.openbook.event.service;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventTag;
 import com.openbook.openbook.event.repository.EventTagRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,5 +21,9 @@ public class EventTagService {
                         .linkedEvent(event)
                         .build()
         );
+    }
+
+    public List<EventTag> getEventTags(Long id) {
+        return eventTagRepository.findAllByLinkedEventId(id);
     }
 }

--- a/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/EventManagerService.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.eventmanager;
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.service.BoothService;
+import com.openbook.openbook.booth.service.BoothTagService;
 import com.openbook.openbook.event.dto.EventLayoutAreaStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayoutArea;
@@ -33,6 +34,7 @@ public class EventManagerService {
     private final EventService eventService;
     private final LayoutAreaService layoutAreaService;
     private final BoothService boothService;
+    private final BoothTagService boothTagService;
     private final AlarmService alarmService;
 
     @Transactional(readOnly = true)
@@ -82,8 +84,7 @@ public class EventManagerService {
         List<BoothAreaData> locationData = eventLayoutAreas.stream()
                 .map(BoothAreaData::of)
                 .collect(Collectors.toList());
-
-        return BoothManageData.of(booth, locationData);
+        return BoothManageData.of(booth, locationData, boothTagService.getBoothTag(booth.getId()));
     }
 
     private BoothStatus getBoothStatus(String status){

--- a/src/main/java/com/openbook/openbook/eventmanager/dto/BoothManageData.java
+++ b/src/main/java/com/openbook/openbook/eventmanager/dto/BoothManageData.java
@@ -4,6 +4,7 @@ import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
 
 import com.openbook.openbook.booth.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.BoothTag;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 
@@ -15,16 +16,18 @@ public record BoothManageData(
         List<BoothAreaData> boothLocationData,
         String registrationDate,
         String description,
+        List<String> tags,
         @Enumerated(EnumType.STRING)
         BoothStatus status
 ) {
-    public static BoothManageData of(Booth booth, List<BoothAreaData> boothLocationData) {
+    public static BoothManageData of(Booth booth, List<BoothAreaData> boothAreas, List<BoothTag> tags) {
         return new BoothManageData(
                 booth.getId(),
                 booth.getName(),
-                boothLocationData,
+                boothAreas,
                 getFormattingDate(booth.getRegisteredAt()),
                 booth.getDescription(),
+                tags.stream().map(BoothTag::getName).toList(),
                 booth.getStatus()
         );
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #92 

행사 및 부스를 조회할 때, 태그 정보도 함께 조회되도록 수정했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 행사 태그, 부스 태그 서비스에 행사, 부스 id로 태그 목록을 찾는 메서드를 구현했습니다.
- 다음 객체에 태그 정보를 추가했습니다.
  - AdminEventData: 사이트 관리자의 행사 정보 조회 객체
  - BoothManageData: 행사 관리자의 부스 정보 조회 객체
  - EventBasicData: 사용자 관점 행사 목록 조회
  - EventDetail: 사용자 관점 행사 상세 조회
  - BoothBasicData: 사용자 관점 부스 목록 조회
  - BoothDetail: 사용자 관점 부스 상세 조회
- 태그 정보는 태그 이름(String)만 포함되도록 구현했습니다.
- BoothTag 엔티티의 필드명을 변경했습니다.
  - 행사 태그와의 통일성을 위해 변경했습니다.
  - booth -> linkedBooth

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 행사 정보 조회 시
![image](https://github.com/user-attachments/assets/46cd9cf4-ead4-4494-9399-0e67495b4941)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 구현하면서, 외래키 조회 시 id로 조회하는 것이 확실히 성능이 낫다는 생각이 들었습니다!
이후 성능 개선을 위해 기존 코드도 id로 조회되도록 변경하면 좋을 것 같네요 😃
- 부스쪽의 객체도 수정하면서 발견한 내용입니다!
현재 행사 상세 조회 부분에는 '현재 로그인한 유저의 행사인지'를 나타내는 boolean 타입 필드가 있는데,
부스 상세 조회에는 해당 필드가 따로 없는 것 같아서 이와 관련해 추가하면 좋을지 의견을 구하고 싶습니다 😃
- 빠뜨린 부분이나 궁금한 점, 개선할 점 등등 의견 편하게 주세요! 😃