### PR TITLE
Fix: 부스 조회에 관리자인지 판별하는 값 추가

### DIFF
--- a/src/main/java/com/openbook/openbook/basicuser/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/basicuser/controller/UserBoothController.java
@@ -37,8 +37,8 @@ public class UserBoothController {
     }
 
     @GetMapping("/{boothId}")
-    public ResponseEntity<BoothDetail> getBooth(@PathVariable Long boothId){
-        return ResponseEntity.ok(userBoothService.getBoothDetail(boothId));
+    public ResponseEntity<BoothDetail> getBooth(Authentication authentication, @PathVariable Long boothId){
+        return ResponseEntity.ok(userBoothService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
     }
 
     @GetMapping("/search/tag")

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -19,10 +19,10 @@ public record BoothDetail(
         List<String> tags,
         Long eventId,
         String eventName,
-        boolean isBoothManager
+        boolean isUserManager
 ) {
 
-    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreas, List<BoothTag> tags, boolean isBoothManager){
+    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreas, List<BoothTag> tags, boolean isUserManager){
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
@@ -34,7 +34,7 @@ public record BoothDetail(
                 tags.stream().map(BoothTag::getName).toList(),
                 booth.getLinkedEvent().getId(),
                 booth.getLinkedEvent().getName(),
-                isBoothManager
+                isUserManager
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/basicuser/dto/response/BoothDetail.java
@@ -16,9 +16,10 @@ public record BoothDetail(
         String closeTime,
         List<BoothAreaData> location,
         String description,
-        String mainImageUrl
+        String mainImageUrl,
+        boolean isBoothManager
 ) {
-    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreaData){
+    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreaData, boolean isBoothManager){
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
@@ -28,7 +29,8 @@ public record BoothDetail(
                 getFormattingTime(booth.getCloseTime()),
                 boothAreaData,
                 booth.getDescription(),
-                booth.getMainImageUrl()
+                booth.getMainImageUrl(),
+                isBoothManager
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/basicuser/service/UserBoothService.java
@@ -34,6 +34,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -99,7 +100,7 @@ public class UserBoothService {
     }
 
     @Transactional(readOnly = true)
-    public BoothDetail getBoothDetail(Long boothId){
+    public BoothDetail getBoothDetail(Long userId, Long boothId){
         Booth booth = boothService.getBoothOrException(boothId);
         if(!booth.getStatus().equals(BoothStatus.APPROVE)){
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
@@ -108,7 +109,7 @@ public class UserBoothService {
                 .stream()
                 .map(BoothAreaData::of)
                 .collect(Collectors.toList());
-        return BoothDetail.of(booth, boothAreaData);
+        return BoothDetail.of(booth, boothAreaData, Objects.equals(booth.getManager().getId(), userId));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #102

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스를 조회할 때 조회한 사용자가 해당 부스의 관리자인지 판별하는 값 추가해서 응답하도록 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/1fadfd76-b36c-4efb-a899-ac71a40d3150">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 구현하다가 부스 관리자인지 판별하는 필드명이 행사 상세 조회에서는 isUserManager로 되어있던데 행사와 부스 관리자에 차별을 주기 위해 isBoothManager로 필드명을 지어 보았습니다! 이에 대해 어떻게 생각하시는지 의견 주시면 감사하겠습니다!
- 외에도 추가 질문사항이나 의견있으시면 말씀해주세요!