### PR TITLE
Fix: 태그 정보를 입력하지 않는 경우 발생하는 오류

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/request/BoothRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/request/BoothRegistrationRequest.java
@@ -15,7 +15,7 @@ public record BoothRegistrationRequest(
         @NotNull MultipartFile mainImage,
         @NotNull @Size(min = 1, max = 3) List<Long> requestAreas,
         @NotBlank String description,
-        @Size(max = 5) List<String> boothTag,
+        @Size(max = 5) List<String> tags,
         String accountBankName,
         String accountNumber
 

--- a/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
@@ -48,7 +48,6 @@ public class UserBoothService {
     private final UserService userService;
     private final AlarmService alarmService;
     private final S3Service s3Service;
-    private final TagUtil tagUtil;
 
     @Transactional
     public void boothRegistration(Long userId, BoothRegistrationRequest request){
@@ -75,7 +74,7 @@ public class UserBoothService {
         Booth booth = boothService.createBooth(boothDTO);
         boothAreaService.setBoothToArea(request.requestAreas(), booth);
         if (request.tags() != null) {
-            tagUtil.getValidTagsOrException(request.tags()).forEach(
+            TagUtil.getValidTagsOrException(request.tags()).forEach(
                     tag ->  boothTagService.createBoothTag(BoothTagDTO.builder()
                             .content(tag)
                             .booth(booth)

--- a/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
@@ -74,8 +74,8 @@ public class UserBoothService {
 
         Booth booth = boothService.createBooth(boothDTO);
         boothAreaService.setBoothToArea(request.requestAreas(), booth);
-        if (request.boothTag() != null) {
-            tagUtil.getValidTagsOrException(request.boothTag()).forEach(
+        if (request.tags() != null) {
+            tagUtil.getValidTagsOrException(request.tags()).forEach(
                     tag ->  boothTagService.createBoothTag(BoothTagDTO.builder()
                             .content(tag)
                             .booth(booth)

--- a/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
@@ -20,6 +20,7 @@ import com.openbook.openbook.booth.controller.response.BoothAreaData;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.util.S3Service;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.global.util.TagUtil;
 import com.openbook.openbook.user.entity.dto.AlarmType;
 import com.openbook.openbook.user.entity.User;
 import com.openbook.openbook.user.service.core.AlarmService;
@@ -47,6 +48,7 @@ public class UserBoothService {
     private final UserService userService;
     private final AlarmService alarmService;
     private final S3Service s3Service;
+    private final TagUtil tagUtil;
 
     @Transactional
     public void boothRegistration(Long userId, BoothRegistrationRequest request){
@@ -72,20 +74,14 @@ public class UserBoothService {
 
         Booth booth = boothService.createBooth(boothDTO);
         boothAreaService.setBoothToArea(request.requestAreas(), booth);
-
-        if(request.boothTag().size() != request.boothTag().stream().distinct().count()){
-            throw new OpenBookException(ErrorCode.ALREADY_TAG_DATA);
+        if (request.boothTag() != null) {
+            tagUtil.getValidTagsOrException(request.boothTag()).forEach(
+                    tag ->  boothTagService.createBoothTag(BoothTagDTO.builder()
+                            .content(tag)
+                            .booth(booth)
+                            .build())
+            );
         }
-
-        for(String boothTag : request.boothTag()){
-            BoothTagDTO boothTagDTO = BoothTagDTO.builder()
-                    .content(boothTag)
-                    .booth(booth)
-                    .build();
-
-            boothTagService.createBoothTag(boothTagDTO);
-        }
-
         alarmService.createAlarm(user, event.getManager(), AlarmType.BOOTH_REQUEST, booth.getName());
     }
 

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothTagService.java
@@ -15,13 +15,13 @@ import org.springframework.stereotype.Service;
 public class BoothTagService {
     private final BoothTagRepository boothTagRepository;
 
-    public BoothTag createBoothTag(BoothTagDTO boothTag){
-        return boothTagRepository.save(
+    public void createBoothTag(BoothTagDTO boothTag){
+        boothTagRepository.save(
                 BoothTag.builder()
                         .name(boothTag.content())
                         .booth(boothTag.booth())
                         .build()
-            );
+        );
     }
 
     public List<BoothTag> getBoothTag(Long id){

--- a/src/main/java/com/openbook/openbook/event/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/UserEventService.java
@@ -43,7 +43,6 @@ public class UserEventService {
     private final BoothService boothService;
     private final AlarmService alarmService;
     private final S3Service s3Service;
-    private final TagUtil tagUtil;
 
     @Transactional
     public void eventRegistration(final Long userId, final EventRegistrationRequest request) {
@@ -73,7 +72,7 @@ public class UserEventService {
         Event event = eventService.createEvent(eventDto);
 
         if (request.tags() != null) {
-            tagUtil.getValidTagsOrException(request.tags()).forEach(
+            TagUtil.getValidTagsOrException(request.tags()).forEach(
                     tag ->  eventTagService.createEventTag(tag, event)
             );
         }

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     ALREADY_RESERVED_AREA(HttpStatus.CONFLICT, "선택 가능한 구역이 아닙니다."),
     INVALID_DATE_RANGE(HttpStatus.CONFLICT, "입력된 날짜 범위가 유효하지 않습니다."),
     INVALID_LAYOUT_ENTRY(HttpStatus.CONFLICT, "입력된 배치도 형식에 오류가 있습니다."),
+    EMPTY_TAG_DATA(HttpStatus.CONFLICT, "공백을 태그로 사용할 수 없습니다."),
     ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
 
     // NOT FOUND

--- a/src/main/java/com/openbook/openbook/global/util/TagUtil.java
+++ b/src/main/java/com/openbook/openbook/global/util/TagUtil.java
@@ -5,12 +5,10 @@ import com.openbook.openbook.global.exception.OpenBookException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TagUtil {
 
-    public Set<String> getValidTagsOrException(List<String> tags) {
+    public static Set<String> getValidTagsOrException(List<String> tags) {
         Set<String> validTags = new HashSet<>();
         tags.stream()
                 .map(String::trim)

--- a/src/main/java/com/openbook/openbook/global/util/TagUtil.java
+++ b/src/main/java/com/openbook/openbook/global/util/TagUtil.java
@@ -1,0 +1,28 @@
+package com.openbook.openbook.global.util;
+
+import com.openbook.openbook.global.exception.ErrorCode;
+import com.openbook.openbook.global.exception.OpenBookException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TagUtil {
+
+    public Set<String> getValidTagsOrException(List<String> tags) {
+        Set<String> validTags = new HashSet<>();
+        tags.stream()
+                .map(String::trim)
+                .forEach(tag -> {
+                    if (tag.isEmpty()) {
+                        throw new OpenBookException(ErrorCode.EMPTY_TAG_DATA);
+                    }
+                    if (!validTags.add(tag)) {
+                        throw new OpenBookException(ErrorCode.ALREADY_TAG_DATA);
+                    }
+                });
+        return validTags;
+    }
+
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #108 

필수 값이 아닌데도 null인 경우의 처리를 하지 않아 발생한 오류입니다.
null이 아닌 경우에만 저장을 진행해 오류를 해결했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 태그 데이터가 공백인 경우의 에러코드를 추가했습니다.
- Util 패키지에 TagUtil 클래스와 getValidTagsOrException 메서드를 추가했습니다. 다음 검증을 진행합니다.
  - 공백 제거
  - 제거 후, 빈 값이라면 에러 반환
  - 중복되는 값이 있는 경우 에러 반환
  
  통과되면 태그 정보가 들어있는 Set을 반환합니다. 
- 부스 태그 생성 메서드에서 return 값이 쓰이지 않아 void로 변경했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
기존 행사 요청, 부스 요청 API 를 사용해 테스트 가능합니다.
태그 정보 없이 생성 요청을 해도 오류가 반환 되지 않습니다.

추가된 응답
- 공백을 태그 정보로 입력할 시 오류
![image](https://github.com/user-attachments/assets/f72e71b7-08c9-4a5e-8af4-dd2f164d7a6b)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- static 메서드로 할까 하다가 너무 남발하는 것 같아 의존성 주입 방식으로 바꿨는데,
관련해서 생각나는 의견 등 있으시면 말씀해주세요!
- 부스 생성 요청의 태그 필드가 boothTag 고 이벤트 생성 요청의 태그 필드가 tags 던데, 통일시키는 것이 좋을까요?
- 기타 궁금한 점, 개선할 점 등등 편하게 의견 주세요! 😃