### PR TITLE
Feat: 행사 검색 API

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -11,6 +11,7 @@ import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,6 +49,14 @@ public class UserEventController {
     @GetMapping("/events/{eventId}")
     public ResponseEntity<EventDetail> getEvent(Authentication authentication, @PathVariable Long eventId) {
         return ResponseEntity.ok(userEventService.getEventDetail(Long.valueOf(authentication.getName()), eventId));
+    }
+
+    @GetMapping("events/search")
+    public ResponseEntity<SliceResponse<UserEventData>> searchEvents(@PageableDefault(size = 6) Pageable pageable,
+                                             @RequestParam(value = "type", defaultValue = "eventName") String searchType,
+                                             @RequestParam(value = "query", defaultValue = "") String name) {
+        Slice<UserEventData> result = userEventService.getEventsSearchBy(pageable, searchType, name);
+        return ResponseEntity.ok(SliceResponse.of(result));
     }
 
 }

--- a/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventRepository.java
@@ -28,6 +28,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Slice<Event> findAllByManagerIdAndStatus(Pageable pageable, Long managerId, EventStatus status);
 
     // USER
+    @Query("SELECT e FROM Event e WHERE e.status = :status AND e.name LIKE %:name% ")
+    Slice<Event> findAllByNameAndStatus(Pageable pageable, String name, EventStatus status);
+
     @Query("SELECT e FROM Event e WHERE e.status = 'APPROVE'")
     Slice<Event> findAllApproved(Pageable pageable);
 

--- a/src/main/java/com/openbook/openbook/event/repository/EventTagRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventTagRepository.java
@@ -1,7 +1,11 @@
 package com.openbook.openbook.event.repository;
 
+import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventTag;
+import com.openbook.openbook.event.entity.dto.EventStatus;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,5 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface EventTagRepository extends JpaRepository<EventTag, Long> {
     @Query("SELECT t FROM EventTag t WHERE t.linkedEvent.id=:eventId")
     List<EventTag> findAllByLinkedEventId(Long eventId);
+
+    @Query("SELECT t.linkedEvent FROM EventTag t WHERE t.name LIKE %:name% AND t.linkedEvent.status=:status")
+    Slice<Event> findLinkedEventsByNameAndEventStatus(Pageable pageable, String name, EventStatus status);
 
 }

--- a/src/main/java/com/openbook/openbook/event/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/UserEventService.java
@@ -88,9 +88,6 @@ public class UserEventService {
             case "tagName" -> eventTagService.getEventsWithTagNameMatchBy(name, EventStatus.APPROVE, pageable);
             default -> throw new OpenBookException(ErrorCode.INVALID_PARAMETER);
         };
-        if(events.isEmpty()) {
-            throw new OpenBookException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
-        }
         return events.map(
                 event -> UserEventData.of(event, eventTagService.getEventTags(event.getId()))
         );

--- a/src/main/java/com/openbook/openbook/event/service/UserEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/UserEventService.java
@@ -27,11 +27,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserEventService {
@@ -78,6 +80,20 @@ public class UserEventService {
         }
 
         alarmService.createAlarm(user, userService.getAdminOrException(), AlarmType.EVENT_REQUEST, eventDto.name());
+    }
+
+    public Slice<UserEventData> getEventsSearchBy(Pageable pageable, String searchType, String name) {
+        Slice<Event> events  = switch (searchType) {
+            case "eventName" -> eventService.getEventsWithNameMatchBy(name, EventStatus.APPROVE, pageable);
+            case "tagName" -> eventTagService.getEventsWithTagNameMatchBy(name, EventStatus.APPROVE, pageable);
+            default -> throw new OpenBookException(ErrorCode.INVALID_PARAMETER);
+        };
+        if(events.isEmpty()) {
+            throw new OpenBookException(ErrorCode.SEARCH_RESULTS_NOT_FOUND);
+        }
+        return events.map(
+                event -> UserEventData.of(event, eventTagService.getEventTags(event.getId()))
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/event/service/core/EventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventService.java
@@ -36,6 +36,10 @@ public class EventService {
         return eventRepository.findAllRequestedByStatus(pageable, status);
     }
 
+    public Slice<Event> getEventsWithNameMatchBy(String name, EventStatus status, Pageable pageable) {
+        return eventRepository.findAllByNameAndStatus(pageable, name, status);
+    }
+
     public Slice<Event> getAllManagedEventsWithStatus(Pageable pageable, Long managerId, EventStatus status) {
         return eventRepository.findAllByManagerIdAndStatus(pageable, managerId, status);
     }

--- a/src/main/java/com/openbook/openbook/event/service/core/EventTagService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventTagService.java
@@ -3,9 +3,12 @@ package com.openbook.openbook.event.service.core;
 
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventTag;
+import com.openbook.openbook.event.entity.dto.EventStatus;
 import com.openbook.openbook.event.repository.EventTagRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,4 +29,9 @@ public class EventTagService {
     public List<EventTag> getEventTags(Long eventId) {
         return eventTagRepository.findAllByLinkedEventId(eventId);
     }
+
+    public Slice<Event> getEventsWithTagNameMatchBy(String name, EventStatus status, Pageable pageable) {
+        return eventTagRepository.findLinkedEventsByNameAndEventStatus(pageable, name, status);
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
 
     // NOT FOUND
+    SEARCH_RESULTS_NOT_FOUND(HttpStatus.NOT_FOUND, "검색 결과가 존재하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 정보를 찾을 수 없습니다."),
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -28,7 +28,6 @@ public enum ErrorCode {
     ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
 
     // NOT FOUND
-    SEARCH_RESULTS_NOT_FOUND(HttpStatus.NOT_FOUND, "검색 결과가 존재하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 정보를 찾을 수 없습니다."),
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #113 
- closed #93 

행사명 또는 행사 태그명으로 행사를 검색하는 API를 개발했습니다.

**GET /events/search**

파라미터
- type (eventName, tagName)
- query
- sort


## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 행사이름과 상태로 행사 찾는 기능 추가
- 행사 상태와 행사 태그 이름으로 연결된 행사 찾는 기능 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- **행사명으로 검색** GET /events/search?type=eventName&query=서울
![image](https://github.com/user-attachments/assets/418a9ebb-926e-425b-9fde-f4d5f661bd8c)

- **태그명으로 검색** GET /events/search?type=tagName&query=테스트
![image](https://github.com/user-attachments/assets/36ab9b7d-1696-4824-8da5-77d526a591ca)

- **검색 결과가 없는 경우** GET /events/search?type=eventName&query=x
![image](https://github.com/user-attachments/assets/1cf1e19e-ccbb-4677-aedc-6a5d2790e193)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- **검색 결과가 없는 경우의 응답에 대해**
처음에는 204 no content로 보내는 걸 생각했다가 검색 결과가 없다는 exception이 발생되도록 변경하였습니다.
![image](https://github.com/user-attachments/assets/07104484-3692-478a-871e-6e4c8d46a752)
그러나 개인적으로 검색 결과가 없는 경우는 404보다는 200인데 응답 데이터가 없는 것이 맞다고 생각해 위 testing 예시처럼 수정하였습니다. 하지만 exception 으로 충분히 처리할 수도 있는 내용이라, 어떤 방식이 나을지 의견을 듣고 싶습니다!
- **API에 대해**
API 엔드포인트를 고민하다보니 행사명 검색과 태그명 검색을 통합해서 파라미터로 처리하는 방향으로 구현하게 되었습니다.
(tag를 경로에 포함시키니 뭔가 tag를 검색하는 것 같아서 파라미터 형태로 변경하게 되었습니다.)
보고 괜찮으시면 부스 검색 방식도 통일시켜도 좋을 것 같아요! 
- **파라미터 query 의 defalt에 대해**
현재 query의 defalt 값을 ""로 해서 결국 지정을 안하면 전체 event에서 가져오게 되는데, 해당 처리를 따로 해야될 지 고민이 되었습니다. 해당 내용에 대해서도 의견을 듣고 싶습니다! 이 내용은 프론트 분들과 상의해도 괜찮을 것 같네요
참고 - 네이버에 내용 없이 검색할 경우 :
![image](https://github.com/user-attachments/assets/9abcf4b7-734b-4530-9491-1b1196983d14)
- **기타**
궁금한 점이나 개선할 점 등 의견 편하게 주세요! 😃