### PR TITLE
Refactor: 부스 검색시 파라미터 값 통합 요청

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -41,15 +41,10 @@ public class UserBoothController {
         return ResponseEntity.ok(userBoothService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
     }
 
-    @GetMapping("/search/boothName")
+    @GetMapping("/search")
     public ResponseEntity<SliceResponse<BoothBasicData>> searchBoothName(@PageableDefault(size = 6) Pageable pageable,
+                                                                         @RequestParam(value = "type") String searchType,
                                                                          @RequestParam(value = "query") String query){
-        return ResponseEntity.ok(SliceResponse.of(userBoothService.searchByBoothName(pageable, query)));
-    }
-
-    @GetMapping("/search/tag")
-    public ResponseEntity<SliceResponse<BoothBasicData>> searchBoothTag(@PageableDefault(size = 6)Pageable pageable,
-                                                                        @RequestParam(value = "query") String query){
-        return ResponseEntity.ok(SliceResponse.of(userBoothService.searchByBoothTag(pageable, query)));
+        return ResponseEntity.ok(SliceResponse.of(userBoothService.searchBoothBy(pageable, searchType, query)));
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
@@ -107,20 +107,17 @@ public class UserBoothService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<BoothBasicData> searchByBoothName(Pageable pageable, String boothName){
-        return boothService.getBoothByName(pageable, boothName, BoothStatus.APPROVE).map(
-                booth -> BoothBasicData.of(
-                        booth, booth.getLinkedEvent(), boothTagService.getBoothTag(booth.getId()))
+    public Slice<BoothBasicData> searchBoothBy(Pageable pageable, String searchType, String name){
+        Slice<Booth> booths = switch (searchType){
+            case "boothName" -> boothService.getBoothByName(pageable, name, BoothStatus.APPROVE);
+            case "tagName" -> boothTagService.getBoothByTag(pageable, name, BoothStatus.APPROVE);
+            default -> throw new OpenBookException(ErrorCode.INVALID_PARAMETER);
+        };
+        return booths.map(
+                booth -> BoothBasicData.of(booth, booth.getLinkedEvent(), boothTagService.getBoothTag(booth.getId()))
         );
     }
 
-    @Transactional(readOnly = true)
-    public Slice<BoothBasicData> searchByBoothTag(Pageable pageable, String boothTag){
-        return boothTagService.getBoothByTag(pageable, boothTag, BoothStatus.APPROVE).map(
-                booth -> BoothBasicData.of(
-                        booth, booth.getLinkedEvent(), boothTagService.getBoothTag(booth.getId()))
-        );
-    }
 
     private boolean hasReservationData(List<Long> eventLayoutAreaList){
         for(Long id : eventLayoutAreaList){


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #118

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스를 검색 할 때 태그명으로 검색할건지 부스명으로 검색할 건지에 대한 api 엔드포인트가 따로 존재했는데, 이전 행사 검색 api와 동일하게 파라미터 값을 한번에 받아  검색 타입(부스명, 태그명)과 쿼리(검색 키워드)에 따른 데이터들을 응답하게 했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- type을 boothName으로 설정했을 경우
<img width="920" alt="image" src="https://github.com/user-attachments/assets/b0da15f4-c261-4c90-bdb0-ec2e04f89870">

- type을 tagName으로 설정했을 경우
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/8677cf5f-4375-44da-b0ad-1d5e16121d17">

- 없는 데이터를 입력했을 경우
<img width="706" alt="image" src="https://github.com/user-attachments/assets/c41dd433-3f54-4635-8ba2-e36007eefb48">


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 앞서 행사 검색 기능을 하신것과 유사하게 구현을 진행했습니다. 확인해보시고 이상 있거나 질문사항이나 의견 편하게 말씀해주세요!
