### PR TITLE
Add: 행사 게시판 기능을 위한 엔티티

### DIFF
--- a/src/main/java/com/openbook/openbook/event/entity/Event.java
+++ b/src/main/java/com/openbook/openbook/event/entity/Event.java
@@ -57,7 +57,10 @@ public class Event extends EntityBasicTime {
     private EventStatus status;
 
     @OneToMany(mappedBy = "linkedEvent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<EventTag> tagDetails = new ArrayList<>();
+    private List<EventTag> eventTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "linkedEvent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<EventBoard> eventBoards = new ArrayList<>();
 
     @Override
     public void setPrePersist() {

--- a/src/main/java/com/openbook/openbook/event/entity/EventBoard.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventBoard.java
@@ -1,7 +1,7 @@
 package com.openbook.openbook.event.entity;
 
 
-import com.openbook.openbook.event.entity.dto.EventStatus;
+import com.openbook.openbook.event.entity.dto.EventBoardType;
 import com.openbook.openbook.global.util.EntityBasicTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,14 +27,16 @@ public class EventBoard extends EntityBasicTime {
 
     private String type;
 
+    private String content;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Event linkedEvent;
 
-
     @Builder
-    public EventBoard(String image, EventStatus type, Event linkedEvent) {
+    public EventBoard(String image, EventBoardType type, String content, Event linkedEvent) {
         this.image = image;
         this.type = type.name();
+        this.content = content;
         this.linkedEvent = linkedEvent;
     }
 }

--- a/src/main/java/com/openbook/openbook/event/entity/EventBoard.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventBoard.java
@@ -1,0 +1,40 @@
+package com.openbook.openbook.event.entity;
+
+
+import com.openbook.openbook.event.entity.dto.EventStatus;
+import com.openbook.openbook.global.util.EntityBasicTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventBoard extends EntityBasicTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String image;
+
+    private String type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Event linkedEvent;
+
+
+    @Builder
+    public EventBoard(String image, EventStatus type, Event linkedEvent) {
+        this.image = image;
+        this.type = type.name();
+        this.linkedEvent = linkedEvent;
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/entity/dto/EventBoardType.java
+++ b/src/main/java/com/openbook/openbook/event/entity/dto/EventBoardType.java
@@ -1,0 +1,6 @@
+package com.openbook.openbook.event.entity.dto;
+
+public enum EventBoardType {
+    NOTICE,
+    EVENT
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #125 

행사 게시글 기능을 위한 엔티티를 추가했습니다. ERD를 참고해 생성했습니다. 
포함되는 속성은 다음과 같습니다.
- 사진
- 내용
- 타입
  - 공지
  - 이벤트
- 연결된 행사
- 생성 시간

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- Event_Board 테이블이 추가되었습니다.
- type 필드 관련해서, 기존의 EventStatus 등과 같이 Enum타입으로 지정하는 방법 대신 String 으로 지정하는 방식을 사용했습니다.  Enum 객체는 엔티티 생성 시 받는 매개변수의 타입에 사용하도록 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 워크벤치에서 테이블이 생성된 것을 확인 가능합니다.
![image](https://github.com/user-attachments/assets/9a1ac796-57bc-465b-b176-e027d055d11b)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 현재 작성된 시간만 엔티티에 포함되는데, 이후 수정 시간도 속성으로 포함되면 좋을까요?
- 처음에는 EventFeed 였다가 일단 게시판이란 의미로 Board 라고 수정했는데 어떤 것이 나은지 의견을 듣고 싶습니다!
- 궁금하신 점, 개선할 부분 등등 의견 편하게 주세요!