### PR TITLE
Add: 부스 서비스 예약 기능을 위한 엔티티 추가

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/entity/Booth.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/Booth.java
@@ -57,6 +57,9 @@ public class Booth extends EntityBasicTime {
     @OneToMany(mappedBy = "linkedBooth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<BoothTag> boothTags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "linkedBooth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<BoothReservation> boothReservations = new ArrayList<>();
+
     @Override
     public void setPrePersist() {
         super.setPrePersist();

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,6 +24,9 @@ public class BoothReservation {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Booth linkedBooth;
+
+    @OneToMany(mappedBy = "linkedReservation", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<BoothReservationDetail> boothReservationDetails = new ArrayList<>();
 
     @Builder
     public BoothReservation(Booth linkedBooth, String content, LocalDate date){

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
@@ -2,10 +2,9 @@ package com.openbook.openbook.booth.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -15,8 +14,14 @@ public class BoothReservation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Booth booth;
+    private String content;
 
-    private LocalDate reserve_date;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Booth linkedBooth;
+
+    @Builder
+    public BoothReservation(Booth linkedBooth, String content){
+        this.content = content;
+        this.linkedBooth = linkedBooth;
+    }
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,12 +18,15 @@ public class BoothReservation {
 
     private String content;
 
+    private LocalDate date;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Booth linkedBooth;
 
     @Builder
-    public BoothReservation(Booth linkedBooth, String content){
+    public BoothReservation(Booth linkedBooth, String content, LocalDate date){
         this.content = content;
+        this.date = date;
         this.linkedBooth = linkedBooth;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
@@ -1,7 +1,6 @@
 package com.openbook.openbook.booth.entity;
 
 import com.openbook.openbook.booth.entity.dto.BoothReservationStatus;
-import com.openbook.openbook.global.util.EntityBasicTime;
 import com.openbook.openbook.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,13 +8,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BoothReservationDetail extends EntityBasicTime {
+public class BoothReservationDetail {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,24 +23,20 @@ public class BoothReservationDetail extends EntityBasicTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private BoothReservation boothReservation;
 
-    private LocalDate date;
-
-    private LocalDateTime time;
+    private String time;
 
     @Enumerated(EnumType.STRING)
     private BoothReservationStatus status;
 
-    @Override
-    public void setPrePersist() {
-        super.setPrePersist();
-        this.status = BoothReservationStatus.WAITING;
+    @PrePersist
+    public void setFirstReservationStatus() {
+        this.status = BoothReservationStatus.EMPTY;
     }
 
     @Builder
-    public BoothReservationDetail(User user, BoothReservation boothReservation, LocalDate date, LocalDateTime time){
+    public BoothReservationDetail(User user, BoothReservation boothReservation, String time){
         this.user = user;
         this.boothReservation = boothReservation;
-        this.date = date;
         this.time = time;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
@@ -21,7 +21,7 @@ public class BoothReservationDetail {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private BoothReservation boothReservation;
+    private BoothReservation linkedReservation;
 
     private String time;
 
@@ -36,7 +36,7 @@ public class BoothReservationDetail {
     @Builder
     public BoothReservationDetail(User user, BoothReservation boothReservation, String time){
         this.user = user;
-        this.boothReservation = boothReservation;
+        this.linkedReservation = boothReservation;
         this.time = time;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
@@ -1,5 +1,7 @@
 package com.openbook.openbook.booth.entity;
 
+import com.openbook.openbook.booth.entity.dto.BoothReservationStatus;
+import com.openbook.openbook.global.util.EntityBasicTime;
 import com.openbook.openbook.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -7,12 +9,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BoothReservationDetail {
+public class BoothReservationDetail extends EntityBasicTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,12 +27,24 @@ public class BoothReservationDetail {
     @ManyToOne(fetch = FetchType.LAZY)
     private BoothReservation boothReservation;
 
+    private LocalDate date;
+
     private LocalDateTime time;
 
+    @Enumerated(EnumType.STRING)
+    private BoothReservationStatus status;
+
+    @Override
+    public void setPrePersist() {
+        super.setPrePersist();
+        this.status = BoothReservationStatus.WAITING;
+    }
+
     @Builder
-    public BoothReservationDetail(User user, BoothReservation boothReservation, LocalDateTime time){
+    public BoothReservationDetail(User user, BoothReservation boothReservation, LocalDate date, LocalDateTime time){
         this.user = user;
         this.boothReservation = boothReservation;
+        this.date = date;
         this.time = time;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/dto/BoothReservationStatus.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/dto/BoothReservationStatus.java
@@ -1,0 +1,10 @@
+package com.openbook.openbook.booth.entity.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum BoothReservationStatus {
+    EMPTY,
+    WAITING,
+    COMPLETE
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #130 
- 부스 이용 고객이 부스 서비스를 예약하기 위한 엔티티와 테이블을 추가 및 수정했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothReservation 엔티티 추가 및 수정
  : id와 content(예약 서비스 내용), linkedBooth 필드를 추가했습니다.

- BoothReservationDetail 엔티티 추가 및 수정
  : 부스 서비스 예약과 관련된 예약 날짜, 시간, 예약자, 예약 상태를 나타내는 예약 상세 엔티티를 추가해서 BoothReservation 엔티티와 연결했습니다.
    status는 BoothReservationStatus enum 클래스를 만들어서 상태를 작성했고 기존 enum으로 상태 관리한 기능들과 마찬가지로 필드에 추가했습니다.

- BoothReservation, BoothReservationDetail 테이블 추가 및 수정
  : 기존 존재했던 테이블들이었지만 칼럼명 수정 및 추가 작업을 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- BoothReservation 테이블
![image](https://github.com/user-attachments/assets/0b8e2f5c-601c-46b0-956b-e55dbd8938e9)
- BoothReservationDetail 테이블
![image](https://github.com/user-attachments/assets/952588b6-1ceb-48e8-a92c-9f7ca7ae2cb5)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 이전 이슈에 작성한 것을 바탕으로 엔티티 구성을 해보았는데 구성에 대해 어떻게 생각하시는지 의견이 궁금합니다!
- 제가 생각나는 대로 우선 필드 및 칼럼명을 작성해보았는데 더 좋은 네이밍 추천받습니다!
- 그 외에 생각나는 의견이나 질문 사항 있으시면 말씀해주세요 😊