### PR TITLE
Feat: 행사 공지사항 등록 API

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/ManagerEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/ManagerEventController.java
@@ -1,15 +1,21 @@
 package com.openbook.openbook.event.controller;
 
+import com.openbook.openbook.event.controller.request.NoticeRegisterRequest;
 import com.openbook.openbook.event.controller.response.ManagerEventData;
 import com.openbook.openbook.event.service.ManagerEventService;
+import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
@@ -25,5 +31,13 @@ public class ManagerEventController {
         return ResponseEntity.ok(SliceResponse.of(
                 managerEventService.getManagedEventList(Long.valueOf(authentication.getName()), pageable, status))
         );
+    }
+
+    @PostMapping("/events/{event_id}/notices")
+    public ResponseEntity<ResponseMessage> postNotice(Authentication authentication,
+                                                        @PathVariable Long event_id,
+                                                        @Valid NoticeRegisterRequest request) {
+        managerEventService.registerEventNotice(Long.valueOf(authentication.getName()), event_id, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
     }
 }

--- a/src/main/java/com/openbook/openbook/event/controller/request/NoticeRegisterRequest.java
+++ b/src/main/java/com/openbook/openbook/event/controller/request/NoticeRegisterRequest.java
@@ -1,0 +1,17 @@
+package com.openbook.openbook.event.controller.request;
+
+import com.openbook.openbook.event.entity.dto.EventNoticeType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record NoticeRegisterRequest(
+        @NotBlank String title,
+        String content,
+        @Enumerated(EnumType.STRING)
+        @NotNull EventNoticeType noticeType,
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/openbook/openbook/event/dto/EventNoticeDto.java
+++ b/src/main/java/com/openbook/openbook/event/dto/EventNoticeDto.java
@@ -1,0 +1,13 @@
+package com.openbook.openbook.event.dto;
+
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.dto.EventNoticeType;
+
+public record EventNoticeDto(
+        String title,
+        String content,
+        String imageUrl,
+        EventNoticeType type,
+        Event linkedEvent
+) {
+}

--- a/src/main/java/com/openbook/openbook/event/entity/Event.java
+++ b/src/main/java/com/openbook/openbook/event/entity/Event.java
@@ -60,7 +60,7 @@ public class Event extends EntityBasicTime {
     private List<EventTag> eventTags = new ArrayList<>();
 
     @OneToMany(mappedBy = "linkedEvent", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<EventBoard> eventBoards = new ArrayList<>();
+    private List<EventNotice> eventNotices = new ArrayList<>();
 
     @Override
     public void setPrePersist() {

--- a/src/main/java/com/openbook/openbook/event/entity/EventNotice.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventNotice.java
@@ -1,7 +1,7 @@
 package com.openbook.openbook.event.entity;
 
 
-import com.openbook.openbook.event.entity.dto.EventBoardType;
+import com.openbook.openbook.event.entity.dto.EventNoticeType;
 import com.openbook.openbook.global.util.EntityBasicTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,26 +18,30 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class EventBoard extends EntityBasicTime {
+public class EventNotice extends EntityBasicTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String image;
+    @NotNull
+    private String title;
+
+    private String content;
 
     private String type;
 
-    private String content;
+    private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Event linkedEvent;
 
     @Builder
-    public EventBoard(String image, EventBoardType type, String content, Event linkedEvent) {
-        this.image = image;
-        this.type = type.name();
+    public EventNotice(String title, String content, EventNoticeType type, String imageUrl, Event linkedEvent) {
+        this.title = title;
         this.content = content;
+        this.type = type.name();
+        this.imageUrl = imageUrl;
         this.linkedEvent = linkedEvent;
     }
 }

--- a/src/main/java/com/openbook/openbook/event/entity/dto/EventNoticeType.java
+++ b/src/main/java/com/openbook/openbook/event/entity/dto/EventNoticeType.java
@@ -1,6 +1,6 @@
 package com.openbook.openbook.event.entity.dto;
 
-public enum EventBoardType {
-    NOTICE,
+public enum EventNoticeType {
+    BASIC,
     EVENT
 }

--- a/src/main/java/com/openbook/openbook/event/repository/EventNoticeRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventNoticeRepository.java
@@ -1,0 +1,10 @@
+package com.openbook.openbook.event.repository;
+
+import com.openbook.openbook.event.entity.EventNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface EventNoticeRepository extends JpaRepository<EventNotice, Long> {
+}

--- a/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
@@ -1,0 +1,27 @@
+package com.openbook.openbook.event.service.core;
+
+
+import com.openbook.openbook.event.dto.EventNoticeDto;
+import com.openbook.openbook.event.entity.EventNotice;
+import com.openbook.openbook.event.repository.EventNoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EventNoticeService {
+
+    private final EventNoticeRepository eventNoticeRepository;
+
+    public void createEventNotice(EventNoticeDto eventNoticeDto) {
+        eventNoticeRepository.save(
+                EventNotice.builder()
+                        .title(eventNoticeDto.title())
+                        .content(eventNoticeDto.content())
+                        .type(eventNoticeDto.type())
+                        .imageUrl(eventNoticeDto.imageUrl())
+                        .linkedEvent(eventNoticeDto.linkedEvent())
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #137 

행사 공지사항을 등록하는 API를 개발하였습니다.
- **Request** 
POST /events/{event_id}/notices
- **Body**
form-data
  - title
  - content
  - noticeType
  - image


## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 기존 행사 공지 테이블, 엔티티명 변경: EventBoard → EventNotice
- 기존 행사 공지 타입 변경: NOTICE → BASIC
- 기존 행사 공지 엔티티에 제목 속성 추가 (title)

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->


- 성공 (201)
![image](https://github.com/user-attachments/assets/83f6d4be-d81d-483c-a11b-dde11db22dac)
workbench
![image](https://github.com/user-attachments/assets/008fd3ba-aae0-4c86-a7cb-652e6582b4cd)


- 로그인한 유저가 해당 행사의 관리자가 아닌 경우 (401)
![image](https://github.com/user-attachments/assets/b483f5d3-2456-4b78-8d30-e355ce065d91)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 일단 제목(title)만 필수 값으로 받도록 구현했는데, 해당 내용도 회의 때 상의해서 정해보면 좋을 것 같습니다!
- 궁금하신 점, 개선하면 좋을 점 등등 편하게 의견 주세요! 😃

