### PR TITLE
Feat: 행사 공지사항 목록 조회

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/ManagerEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/ManagerEventController.java
@@ -1,6 +1,6 @@
 package com.openbook.openbook.event.controller;
 
-import com.openbook.openbook.event.controller.request.NoticeRegisterRequest;
+import com.openbook.openbook.event.controller.request.EventNoticeRegisterRequest;
 import com.openbook.openbook.event.controller.response.ManagerEventData;
 import com.openbook.openbook.event.service.ManagerEventService;
 import com.openbook.openbook.global.dto.ResponseMessage;
@@ -36,7 +36,7 @@ public class ManagerEventController {
     @PostMapping("/events/{event_id}/notices")
     public ResponseEntity<ResponseMessage> postNotice(Authentication authentication,
                                                         @PathVariable Long event_id,
-                                                        @Valid NoticeRegisterRequest request) {
+                                                        @Valid EventNoticeRegisterRequest request) {
         managerEventService.registerEventNotice(Long.valueOf(authentication.getName()), event_id, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
     }

--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -1,11 +1,13 @@
 package com.openbook.openbook.event.controller;
 
 
+import com.openbook.openbook.event.controller.response.EventNoticeData;
 import com.openbook.openbook.event.controller.response.UserEventData;
 import com.openbook.openbook.event.controller.response.EventDetail;
 import com.openbook.openbook.event.controller.response.EventLayoutStatus;
-import com.openbook.openbook.event.service.UserEventService;
+import com.openbook.openbook.event.service.EventCommonService;
 import com.openbook.openbook.event.controller.request.EventRegistrationRequest;
+import com.openbook.openbook.event.service.EventLayoutCommonService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
@@ -26,36 +28,43 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserEventController {
 
-    private final UserEventService userEventService;
+    private final EventCommonService eventCommonService;
+    private final EventLayoutCommonService eventLayoutCommonService;
 
     @PostMapping("/events")
     public ResponseEntity<ResponseMessage> registration(Authentication authentication,
                                                         @Valid EventRegistrationRequest request) {
-        userEventService.eventRegistration(Long.valueOf(authentication.getName()), request);
+        eventCommonService.eventRegistration(Long.valueOf(authentication.getName()), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("신청이 완료되었습니다."));
     }
 
     @GetMapping("/events/{eventId}/layout/status")
     public ResponseEntity<EventLayoutStatus> getEventLayoutStatus(@PathVariable Long eventId) {
-        return ResponseEntity.ok(userEventService.getEventLayoutStatus(eventId));
+        return ResponseEntity.ok(eventLayoutCommonService.getEventLayoutStatus(eventId));
     }
 
     @GetMapping("/events")
     public ResponseEntity<SliceResponse<UserEventData>> getEvents(@RequestParam(defaultValue = "all") String progress,
                                                                   @PageableDefault(size = 6) Pageable pageable) {
-        return ResponseEntity.ok(SliceResponse.of(userEventService.getEventBasicData(pageable, progress)));
+        return ResponseEntity.ok(SliceResponse.of(eventCommonService.getEventBasicData(pageable, progress)));
     }
 
     @GetMapping("/events/{eventId}")
     public ResponseEntity<EventDetail> getEvent(Authentication authentication, @PathVariable Long eventId) {
-        return ResponseEntity.ok(userEventService.getEventDetail(Long.valueOf(authentication.getName()), eventId));
+        return ResponseEntity.ok(eventCommonService.getEventDetail(Long.valueOf(authentication.getName()), eventId));
+    }
+
+    @GetMapping("/events/{event_id}/notices")
+    public ResponseEntity<SliceResponse<EventNoticeData>> getEventNotices(@PathVariable Long event_id,
+                                                                          @PageableDefault(size = 6) Pageable pageable) {
+        return ResponseEntity.ok(SliceResponse.of(eventCommonService.getEventNotice(event_id, pageable)));
     }
 
     @GetMapping("events/search")
     public ResponseEntity<SliceResponse<UserEventData>> searchEvents(@PageableDefault(size = 6) Pageable pageable,
                                              @RequestParam(value = "type", defaultValue = "eventName") String searchType,
                                              @RequestParam(value = "query", defaultValue = "") String name) {
-        Slice<UserEventData> result = userEventService.getEventsSearchBy(pageable, searchType, name);
+        Slice<UserEventData> result = eventCommonService.getEventsSearchBy(pageable, searchType, name);
         return ResponseEntity.ok(SliceResponse.of(result));
     }
 

--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -56,7 +56,7 @@ public class UserEventController {
 
     @GetMapping("/events/{event_id}/notices")
     public ResponseEntity<SliceResponse<EventNoticeData>> getEventNotices(@PathVariable Long event_id,
-                                                                          @PageableDefault(size = 6) Pageable pageable) {
+                                                                          @PageableDefault(size = 5) Pageable pageable) {
         return ResponseEntity.ok(SliceResponse.of(eventCommonService.getEventNotice(event_id, pageable)));
     }
 

--- a/src/main/java/com/openbook/openbook/event/controller/request/EventNoticeRegisterRequest.java
+++ b/src/main/java/com/openbook/openbook/event/controller/request/EventNoticeRegisterRequest.java
@@ -7,9 +7,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
-public record NoticeRegisterRequest(
+public record EventNoticeRegisterRequest(
         @NotBlank String title,
-        String content,
+        @NotBlank String content,
         @Enumerated(EnumType.STRING)
         @NotNull EventNoticeType noticeType,
         MultipartFile image

--- a/src/main/java/com/openbook/openbook/event/controller/response/EventNoticeData.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/EventNoticeData.java
@@ -1,0 +1,23 @@
+package com.openbook.openbook.event.controller.response;
+
+import com.openbook.openbook.event.entity.EventNotice;
+import com.openbook.openbook.event.entity.dto.EventNoticeType;
+import java.time.LocalDateTime;
+
+public record EventNoticeData(
+        String title,
+        String content,
+        String imageUrl,
+        EventNoticeType type,
+        LocalDateTime registeredAt
+) {
+    public static EventNoticeData of(EventNotice notice) {
+        return new EventNoticeData(
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getImageUrl(),
+                EventNoticeType.valueOf(notice.getType()),
+                notice.getRegisteredAt()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/event/repository/EventNoticeRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventNoticeRepository.java
@@ -1,10 +1,15 @@
 package com.openbook.openbook.event.repository;
 
 import com.openbook.openbook.event.entity.EventNotice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public interface EventNoticeRepository extends JpaRepository<EventNotice, Long> {
+
+    Slice<EventNotice> findByLinkedEventId(Long linkedEventId, Pageable pageable);
+
 }

--- a/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
+++ b/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
@@ -110,29 +110,21 @@ public class EventCommonService {
         if(!event.getStatus().equals(EventStatus.APPROVE)) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
-        List<EventTag> tags = eventTagService.getEventTags(event.getId());
         int boothCount = boothService.getBoothCountByEvent(event);
-        return EventDetail.of(event, userId, tags, boothCount);
+        return EventDetail.of(event, userId, eventTagService.getEventTags(event.getId()), boothCount);
     }
 
     @Transactional(readOnly = true)
-    public EventLayoutStatus getEventLayoutStatus(Long eventId) {
+    public Slice<EventNoticeData> getEventNotice(final Long eventId, Pageable pageable) {
         Event event = eventService.getEventOrException(eventId);
-        if(isNotRecruitmentPeriod(event.getBoothRecruitmentStartDate(), event.getBoothRecruitmentEndDate())) {
-            throw new OpenBookException(ErrorCode.INACCESSIBLE_PERIOD);
-        }
-        return userEventLayoutService.getLayoutStatus(event.getLayout());
+        return eventNoticeService.getNotices(event, pageable).map(EventNoticeData::of);
     }
+
 
     private void dateValidityCheck(LocalDate startDate, LocalDate endDate) {
         if(startDate.isAfter(endDate)) {
             throw new OpenBookException(ErrorCode.INVALID_DATE_RANGE);
         }
-    }
-
-    private boolean isNotRecruitmentPeriod(LocalDate startDate, LocalDate endDate) {
-        LocalDate now = LocalDate.now();
-        return now.isBefore(startDate) || now.isAfter(endDate);
     }
 
     private List<BoothAreaCreateData> getBoothAreaCreateList(List<String> classifications, List<Integer> maxNumbers) {

--- a/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
+++ b/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.event.service;
 
 
 import com.openbook.openbook.event.controller.request.EventRegistrationRequest;
+import com.openbook.openbook.event.controller.response.EventNoticeData;
 import com.openbook.openbook.event.dto.EventLayoutCreateData;
 import com.openbook.openbook.booth.dto.BoothAreaCreateData;
 import com.openbook.openbook.event.controller.response.UserEventData;
@@ -9,10 +10,12 @@ import com.openbook.openbook.event.controller.response.EventDetail;
 import com.openbook.openbook.event.controller.response.EventLayoutStatus;
 import com.openbook.openbook.booth.service.core.BoothService;
 import com.openbook.openbook.event.dto.EventDTO;
+import com.openbook.openbook.event.dto.EventNoticeDto;
 import com.openbook.openbook.event.entity.dto.EventStatus;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventLayout;
 import com.openbook.openbook.event.entity.EventTag;
+import com.openbook.openbook.event.service.core.EventNoticeService;
 import com.openbook.openbook.event.service.core.EventService;
 import com.openbook.openbook.event.service.core.EventTagService;
 import com.openbook.openbook.global.exception.ErrorCode;
@@ -36,12 +39,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class UserEventService {
+public class EventCommonService {
 
     private final UserService userService;
     private final EventService eventService;
     private final EventTagService eventTagService;
-    private final UserEventLayoutService userEventLayoutService;
+    private final EventNoticeService eventNoticeService;
+    private final EventLayoutCommonService eventLayoutCommonService;
     private final BoothService boothService;
     private final AlarmService alarmService;
     private final S3Service s3Service;
@@ -56,8 +60,7 @@ public class UserEventService {
 
         List<BoothAreaCreateData> areaData = getBoothAreaCreateList(request.areaClassifications(), request.areaMaxNumbers());
         EventLayoutCreateData layoutData = new EventLayoutCreateData(request.layoutType(),request.layoutImages(), areaData);
-        EventLayout layout = userEventLayoutService.createEventLayout(layoutData);
-
+        EventLayout layout = eventLayoutCommonService.createEventLayout(layoutData);
 
         EventDTO eventDto = EventDTO.builder()
                 .manager(user)

--- a/src/main/java/com/openbook/openbook/event/service/ManagerEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/ManagerEventService.java
@@ -1,6 +1,6 @@
 package com.openbook.openbook.event.service;
 
-import com.openbook.openbook.event.controller.request.NoticeRegisterRequest;
+import com.openbook.openbook.event.controller.request.EventNoticeRegisterRequest;
 import com.openbook.openbook.event.controller.response.ManagerEventData;
 import com.openbook.openbook.event.dto.EventNoticeDto;
 import com.openbook.openbook.event.entity.Event;
@@ -41,7 +41,7 @@ public class ManagerEventService {
     }
 
     @Transactional
-    public void registerEventNotice(Long userId, Long eventId, NoticeRegisterRequest request) {
+    public void registerEventNotice(Long userId, Long eventId, EventNoticeRegisterRequest request) {
         Event event = eventService.getEventOrException(eventId);
         if(!event.getManager().getId().equals(userId)) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);

--- a/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
@@ -2,9 +2,12 @@ package com.openbook.openbook.event.service.core;
 
 
 import com.openbook.openbook.event.dto.EventNoticeDto;
+import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventNotice;
 import com.openbook.openbook.event.repository.EventNoticeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,4 +27,9 @@ public class EventNoticeService {
                         .build()
         );
     }
+
+    public Slice<EventNotice> getNotices(Event event, Pageable pageable) {
+        return eventNoticeRepository.findByLinkedEventId(event.getId(), pageable);
+    }
+
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #140 

행사의 공지 사항의 목록을 조회하는 api 를 개발했습니다.
- GET /events/:event_id/notices

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->

이벤트 공용 서비스 클래스명 변경 ( #114 )
- UserEventService -> EventCommonService
- UserEventLayoutService -> EventLayoutCommonService

 
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 성공 (200)
![image](https://github.com/user-attachments/assets/8931f570-19bb-4395-aaeb-8350e5fb4786)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 피그마를 보고 일단 응답을 Slice 형태로 했는데, 한번에 보일 값 등등 회의 때 물어보고 확실히 정해도 될 것 같아요
  - 확정된 내용: Slice 사용, 한번에 5개
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요 ! 😃