### PR TITLE
Fix: 마이페이지 부스 조회 필터링 조건 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothRepository.java
@@ -31,4 +31,7 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     @Query("SELECT b FROM Booth b WHERE b.manager.id=:managerId AND b.status=:boothStatus")
     Slice<Booth> findAllByManagerIdAndStatus(Pageable pageable, Long managerId, BoothStatus boothStatus);
+
+    @Query("SELECT b FROM Booth b WHERE b.manager.id=:managerId")
+    Slice<Booth> findAllByManagerId(Pageable pageable, Long managerId);
 }

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -52,7 +52,7 @@ public class ManagerBoothService {
     public Slice<BoothManageData> getManagedBoothList(Long managerId, Pageable pageable, String status){
         userService.getUserOrException(managerId);
         Slice<Booth> booths = (status.equals("ALL"))
-                ? boothService.getAllManagedBooths(pageable)
+                ? boothService.getAllManagedBooths(pageable, managerId)
                 : boothService.getAllManagedBoothsByStatus(pageable, managerId, BoothStatus.valueOf(status));
 
         return booths.map(booth -> {

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothService.java
@@ -65,8 +65,8 @@ public class BoothService {
         return boothRepository.findAllByNameAndStatus(pageable, boothName, status);
     }
 
-    public Slice<Booth> getAllManagedBooths(Pageable pageable){
-        return boothRepository.findAll(pageable);
+    public Slice<Booth> getAllManagedBooths(Pageable pageable, Long managerId){
+        return boothRepository.findAllByManagerId(pageable, managerId);
     }
 
     public Slice<Booth> getAllManagedBoothsByStatus(Pageable pageable, Long managerId, BoothStatus boothStatus){


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #147

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- status 없이 기본적으로 로그인한 유저의 부스를 불러올 때 사용하는 쿼리문을 findAll에서 findAllByManagerId로 필터링조건을 추가했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- testName 이라는 유저의 부스만 불러온 결과
![image](https://github.com/user-attachments/assets/599bc68c-a99c-4ca0-b25f-c28b4d04362c)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 수정사항이나 기타 의견 있으시면 말씀해주세요!