### PR TITLE
Feat: 행사 공지 단 건 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -57,7 +57,12 @@ public class UserEventController {
     @GetMapping("/events/{event_id}/notices")
     public ResponseEntity<SliceResponse<EventNoticeData>> getEventNotices(@PathVariable Long event_id,
                                                                           @PageableDefault(size = 5) Pageable pageable) {
-        return ResponseEntity.ok(SliceResponse.of(eventCommonService.getEventNotice(event_id, pageable)));
+        return ResponseEntity.ok(SliceResponse.of(eventCommonService.getEventNotices(event_id, pageable)));
+    }
+
+    @GetMapping("/events/notices/{notice_id}")
+    public ResponseEntity<EventNoticeData> getEventNotice(@PathVariable Long notice_id) {
+        return ResponseEntity.ok(eventCommonService.getEventNotice(notice_id));
     }
 
     @GetMapping("events/search")

--- a/src/main/java/com/openbook/openbook/event/controller/response/EventNoticeData.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/EventNoticeData.java
@@ -12,7 +12,8 @@ public record EventNoticeData(
         EventNoticeType type,
         LocalDateTime registeredAt,
         long eventId,
-        String eventName
+        String eventName,
+        long eventManagerId
 ) {
     public static EventNoticeData of(EventNotice notice) {
         return new EventNoticeData(
@@ -23,7 +24,8 @@ public record EventNoticeData(
                 EventNoticeType.valueOf(notice.getType()),
                 notice.getRegisteredAt(),
                 notice.getLinkedEvent().getId(),
-                notice.getLinkedEvent().getName()
+                notice.getLinkedEvent().getName(),
+                notice.getLinkedEvent().getManager().getId()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/event/controller/response/EventNoticeData.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/EventNoticeData.java
@@ -5,19 +5,25 @@ import com.openbook.openbook.event.entity.dto.EventNoticeType;
 import java.time.LocalDateTime;
 
 public record EventNoticeData(
+        long id,
         String title,
         String content,
         String imageUrl,
         EventNoticeType type,
-        LocalDateTime registeredAt
+        LocalDateTime registeredAt,
+        long eventId,
+        String eventName
 ) {
     public static EventNoticeData of(EventNotice notice) {
         return new EventNoticeData(
+                notice.getId(),
                 notice.getTitle(),
                 notice.getContent(),
                 notice.getImageUrl(),
                 EventNoticeType.valueOf(notice.getType()),
-                notice.getRegisteredAt()
+                notice.getRegisteredAt(),
+                notice.getLinkedEvent().getId(),
+                notice.getLinkedEvent().getName()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
+++ b/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
@@ -115,11 +115,15 @@ public class EventCommonService {
     }
 
     @Transactional(readOnly = true)
-    public Slice<EventNoticeData> getEventNotice(final Long eventId, Pageable pageable) {
+    public Slice<EventNoticeData> getEventNotices(final Long eventId, Pageable pageable) {
         Event event = eventService.getEventOrException(eventId);
         return eventNoticeService.getNotices(event, pageable).map(EventNoticeData::of);
     }
 
+    @Transactional(readOnly = true)
+    public EventNoticeData getEventNotice(final Long noticeId) {
+        return EventNoticeData.of(eventNoticeService.getEventNoticeOrException(noticeId));
+    }
 
     private void dateValidityCheck(LocalDate startDate, LocalDate endDate) {
         if(startDate.isAfter(endDate)) {

--- a/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
@@ -5,6 +5,8 @@ import com.openbook.openbook.event.dto.EventNoticeDto;
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventNotice;
 import com.openbook.openbook.event.repository.EventNoticeRepository;
+import com.openbook.openbook.global.exception.ErrorCode;
+import com.openbook.openbook.global.exception.OpenBookException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -15,6 +17,12 @@ import org.springframework.stereotype.Service;
 public class EventNoticeService {
 
     private final EventNoticeRepository eventNoticeRepository;
+
+    public EventNotice getEventNoticeOrException(final Long id) {
+        return eventNoticeRepository.findById(id).orElseThrow(() ->
+                new OpenBookException(ErrorCode.EVENT_NOTICE_NOT_FOUND)
+        );
+    }
 
     public void createEventNotice(EventNoticeDto eventNoticeDto) {
         eventNoticeRepository.save(

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     // NOT FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 정보를 찾을 수 없습니다."),
+    EVENT_NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 공지 정보를 찾을 수 없습니다."),
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #146 

행사 공지 단 건을 조회하는 API 를 개발했습니다.
- GET /events/notices/:notice_id
- 반환 값
  - 공지 id
  - 공지 제목
  - 공지 내용
  - 공지 이미지
  - 공지 타입 (BASIC/EVENT)
  - 생성 시간
  - 행사 id
  - 행사 명
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- **EventNoticeData** 공지 조회 시의 반환 객체에 값을 추가했습니다. 
추가된 값
  - 공지 id
  - 행사 id
  - 행사 명
- **ErrorCode** 행사 공지가 없는 경우의 오류 코드를 추가했습니다. 
  - EVENT_NOTICE_NOT_FOUND

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
GET {local}/events/notices/1 요청을 통해 확인했습니다.

- 성공 (200)
![image](https://github.com/user-attachments/assets/1de0e929-66b4-4260-a025-1016500b3f5a)
- 일치하는 행사 id 없는 경우 (404)
![image](https://github.com/user-attachments/assets/9048576e-21ac-4797-9319-8a9b95a96264)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 개발 중에 갑자기 든 생각인데 EventNoticeData 같이 응답 객체를 ~Data 라고 네이밍 하고 있는데 다음에 응답 객체 통일할 때 Response 로 네이밍 하는 건 어떨까요? 괜찮으면 이후 리팩터링 시에 반영하겠습니다!
- 그 외 궁금한 점, 개선할 점 등 의견 편하게 주세요! 😃