### PR TITLE
Feat: 부스 상품 카테고리 기능

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/request/ProductRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/request/ProductRegistrationRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public record ProductRegistrationRequest(
+        long categoryId,
         @NotBlank String name,
         String description,
         int stock,

--- a/src/main/java/com/openbook/openbook/booth/dto/BoothProductDto.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/BoothProductDto.java
@@ -1,12 +1,15 @@
 package com.openbook.openbook.booth.dto;
 
-import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.BoothProductCategory;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record BoothProductDto(
         String name,
         String description,
         int stock,
         int price,
-        Booth linkedBooth
+        List<MultipartFile> images,
+        BoothProductCategory linkedCategory
 ) {
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/Booth.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/Booth.java
@@ -61,7 +61,7 @@ public class Booth extends EntityBasicTime {
     private List<BoothReservation> boothReservations = new ArrayList<>();
 
     @OneToMany(mappedBy = "linkedBooth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<BoothProduct> boothProducts = new ArrayList<>();
+    private List<BoothProductCategory> boothProductCategories = new ArrayList<>();
 
     @OneToMany(mappedBy = "linkedBooth", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<BoothNotice> boothNotices = new ArrayList<>();

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothProduct.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothProduct.java
@@ -26,18 +26,18 @@ public class BoothProduct {
     private int price;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Booth linkedBooth;
+    private BoothProductCategory linkedCategory;
 
     @OneToMany(mappedBy = "linkedProduct", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<BoothProductImage> productImages = new ArrayList<>();
 
     @Builder
-    public BoothProduct(String name, String description, int stock, int price, Booth linkedBooth) {
+    public BoothProduct(String name, String description, int stock, int price, BoothProductCategory linkedCategory) {
         this.name = name;
         this.description = description;
         this.stock = stock;
         this.price = price;
-        this.linkedBooth = linkedBooth;
+        this.linkedCategory = linkedCategory;
     }
 
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothProductCategory.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothProductCategory.java
@@ -1,0 +1,40 @@
+package com.openbook.openbook.booth.entity;
+
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoothProductCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Booth linkedBooth;
+
+    @OneToMany(mappedBy = "linkedCategory", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<BoothProduct> boothProducts = new ArrayList<>();
+
+    @Builder
+    public BoothProductCategory(String name, Booth linkedBooth) {
+        this.name = name;
+        this.linkedBooth = linkedBooth;
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothProductCategoryRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothProductCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.openbook.openbook.booth.repository;
+
+
+import com.openbook.openbook.booth.entity.BoothProductCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoothProductCategoryRepository extends JpaRepository<BoothProductCategory, Long> {
+}

--- a/src/main/java/com/openbook/openbook/booth/service/EventManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/EventManagerBoothService.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.booth.service;
 import com.openbook.openbook.booth.entity.dto.BoothStatus;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.service.core.BoothAreaService;
+import com.openbook.openbook.booth.service.core.BoothProductService;
 import com.openbook.openbook.booth.service.core.BoothService;
 import com.openbook.openbook.booth.service.core.BoothTagService;
 import com.openbook.openbook.booth.entity.dto.BoothAreaStatus;
@@ -35,6 +36,7 @@ public class EventManagerBoothService {
     private final BoothAreaService boothAreaService;
     private final BoothService boothService;
     private final BoothTagService boothTagService;
+    private final BoothProductService boothProductService;
     private final AlarmService alarmService;
 
     @Transactional(readOnly = true)
@@ -71,12 +73,12 @@ public class EventManagerBoothService {
 
         if(boothStatus.equals(BoothStatus.APPROVE)){
             changeAreaStatus(boothAreas, BoothAreaStatus.COMPLETE);
+            boothProductService.createProductCategory("기본", booth);
             alarmService.createAlarm(user, booth.getManager(), AlarmType.BOOTH_APPROVED, booth.getName());
         } else if (boothStatus.equals(BoothStatus.REJECT)) {
             changeAreaStatus(boothAreas, BoothAreaStatus.EMPTY);
             alarmService.createAlarm(user, booth.getManager(), AlarmType.BOOTH_REJECTED, booth.getName());
         }
-
     }
 
     private BoothManageData convertToBoothManageData(Booth booth) {

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -88,14 +88,10 @@ public class ManagerBoothService {
         if(!booth.getStatus().equals(BoothStatus.APPROVE)) {
             throw new OpenBookException(ErrorCode.BOOTH_NOT_APPROVED);
         }
-        BoothProduct product = boothProductService.createBoothProduct(new BoothProductDto(
-                request.name(), request.description(), request.stock(), request.price(), booth)
+        boothProductService.createBoothProduct(new BoothProductDto(
+                request.name(), request.description(), request.stock(), request.price(),
+                request.images(), boothProductService.getProductCategoryOrException(request.categoryId()))
         );
-        if(request.images() != null && !request.images().isEmpty()){
-            request.images().forEach(image -> {
-                boothProductService.createBoothProductImage(s3Service.uploadFileAndGetUrl(image), product);
-            });
-        }
     }
 
     @Transactional

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -3,7 +3,9 @@ package com.openbook.openbook.booth.service.core;
 
 import com.openbook.openbook.booth.dto.BoothProductDto;
 import com.openbook.openbook.booth.entity.BoothProduct;
+import com.openbook.openbook.booth.entity.BoothProductCategory;
 import com.openbook.openbook.booth.entity.BoothProductImage;
+import com.openbook.openbook.booth.repository.BoothProductCategoryRepository;
 import com.openbook.openbook.booth.repository.BoothProductImageRepository;
 import com.openbook.openbook.booth.repository.BoothProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +18,17 @@ public class BoothProductService {
     private final BoothProductRepository boothProductRepository;
     private final BoothProductImageRepository boothProductImageRepository;
 
-    public BoothProduct createBoothProduct(final BoothProductDto boothProduct) {
-        return boothProductRepository.save(
+    public void createProductCategory(String categoryName, Booth linkedBooth) {
+        categoryRepository.save(
+                BoothProductCategory.builder()
+                        .name(categoryName)
+                        .linkedBooth(linkedBooth)
+                        .build()
+        );
+    }
+
+    public void createBoothProduct(final BoothProductDto boothProduct) {
+        BoothProduct product = boothProductRepository.save(
                 BoothProduct.builder()
                         .name(boothProduct.name())
                         .description(boothProduct.description())

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -2,14 +2,19 @@ package com.openbook.openbook.booth.service.core;
 
 
 import com.openbook.openbook.booth.dto.BoothProductDto;
+import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothProduct;
 import com.openbook.openbook.booth.entity.BoothProductCategory;
 import com.openbook.openbook.booth.entity.BoothProductImage;
 import com.openbook.openbook.booth.repository.BoothProductCategoryRepository;
 import com.openbook.openbook.booth.repository.BoothProductImageRepository;
 import com.openbook.openbook.booth.repository.BoothProductRepository;
+import com.openbook.openbook.global.exception.ErrorCode;
+import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.global.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,7 @@ public class BoothProductService {
     private final BoothProductCategoryRepository categoryRepository;
     private final BoothProductRepository boothProductRepository;
     private final BoothProductImageRepository boothProductImageRepository;
+    private final S3Service s3Service;
 
     public BoothProductCategory getProductCategoryOrException(final long id) {
         return categoryRepository.findById(id).orElseThrow(()->
@@ -44,12 +50,17 @@ public class BoothProductService {
                         .linkedBooth(boothProduct.linkedBooth())
                         .build()
         );
+        if(boothProduct.images()!=null && !boothProduct.images().isEmpty()) {
+            boothProduct.images().forEach(imageUrl -> {
+                createBoothProductImage(imageUrl, product);
+            });
+        }
     }
 
-    public void createBoothProductImage(final String imageUrl, final BoothProduct boothProduct) {
+    public void createBoothProductImage(final MultipartFile imageUrl, final BoothProduct boothProduct) {
         boothProductImageRepository.save(
                 BoothProductImage.builder()
-                        .imageUrl(imageUrl)
+                        .imageUrl(s3Service.uploadFileAndGetUrl(imageUrl))
                         .linkedProduct(boothProduct)
                         .build()
         );

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -15,8 +15,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BoothProductService {
 
+    private final BoothProductCategoryRepository categoryRepository;
     private final BoothProductRepository boothProductRepository;
     private final BoothProductImageRepository boothProductImageRepository;
+
+    public BoothProductCategory getProductCategoryOrException(final long id) {
+        return categoryRepository.findById(id).orElseThrow(()->
+                new OpenBookException(ErrorCode.PRODUCT_CATEGORY_NOT_FOUND)
+        );
+    }
 
     public void createProductCategory(String categoryName, Booth linkedBooth) {
         categoryRepository.save(

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -47,7 +47,7 @@ public class BoothProductService {
                         .description(boothProduct.description())
                         .stock(boothProduct.stock())
                         .price(boothProduct.price())
-                        .linkedBooth(boothProduct.linkedBooth())
+                        .linkedCategory(boothProduct.linkedCategory())
                         .build()
         );
         if(boothProduct.images()!=null && !boothProduct.images().isEmpty()) {

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 정보를 찾을 수 없습니다."),
     EVENT_NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 공지 정보를 찾을 수 없습니다."),
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),
+    PRODUCT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 카테고리를 찾을 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
 


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #152 

부스 상품 상위에 카테고리가 있도록 카테고리 기능을 추가했습니다.


## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스 상품 카테고리 엔티티 추가, 기존 관계 수정
  - 부스와 부스 상품 카테고리를 연결
  - 부스와 부스 상품 연결 해제
  - 부스 상품 카테고리와 부스 상품을 연결
- 부스 승인 시 (상태 APPROVE 변경시) 기본 부스 상품 카테고리가 생성되도록 추가
- 상품 생성 시, 이미지도 같이 생성하도록 메서드 리팩터링
- 기존의 로그인한 유저가 부스의 매니저인지, 부스가 승인된 상태인지 확인하는 로직을 하나의 메서드로 통합


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 리팩터링한 메서드 명을 일단 유효한 부스를 가져온다는 의미로 `getValidBoothOrException` 라고 지었는데, 다른 좋은 네이밍 생각나시면 말씀해주시면 감사하겠습니다 !!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃