### PR TITLE
Feat: 부스 공지사항 등록

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/ManagerBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/ManagerBoothController.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.booth.controller;
 
+import com.openbook.openbook.booth.controller.request.BoothNoticeRegisterRequest;
 import com.openbook.openbook.booth.controller.request.ReserveRegistrationRequest;
 import com.openbook.openbook.booth.controller.request.ProductRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothManageData;
@@ -53,5 +54,13 @@ public class ManagerBoothController {
                                                                @PathVariable Long boothId){
         managerBoothService.addReservation(Long.valueOf(authentication.getName()), request, boothId);
         return ResponseEntity.ok(new ResponseMessage("예약 추가에 성공했습니다."));
+    }
+
+    @PostMapping("/booths/{boothId}/notices")
+    public ResponseEntity<ResponseMessage> postNotice(Authentication authentication,
+                                                      @PathVariable Long boothId,
+                                                      @Valid BoothNoticeRegisterRequest boothNoticeRegisterRequest){
+        managerBoothService.registerBoothNotice(Long.valueOf(authentication.getName()), boothId, boothNoticeRegisterRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/controller/request/BoothNoticeRegisterRequest.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/request/BoothNoticeRegisterRequest.java
@@ -1,0 +1,14 @@
+package com.openbook.openbook.booth.controller.request;
+
+import com.openbook.openbook.booth.entity.dto.BoothNoticeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record BoothNoticeRegisterRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        @NotNull BoothNoticeType noticeType,
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/openbook/openbook/booth/dto/BoothNoticeDto.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/BoothNoticeDto.java
@@ -1,0 +1,13 @@
+package com.openbook.openbook.booth.dto;
+
+import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.dto.BoothNoticeType;
+
+public record BoothNoticeDto(
+        String title,
+        String content,
+        String imageUrl,
+        BoothNoticeType type,
+        Booth linkedBooth
+) {
+}

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothNoticeRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothNoticeRepository.java
@@ -1,0 +1,7 @@
+package com.openbook.openbook.booth.repository;
+
+import com.openbook.openbook.booth.entity.BoothNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoothNoticeRepository extends JpaRepository<BoothNotice, Long> {
+}

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -1,8 +1,10 @@
 package com.openbook.openbook.booth.service;
 
+import com.openbook.openbook.booth.controller.request.BoothNoticeRegisterRequest;
 import com.openbook.openbook.booth.controller.request.ReserveRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothAreaData;
 import com.openbook.openbook.booth.controller.response.BoothManageData;
+import com.openbook.openbook.booth.dto.BoothNoticeDto;
 import com.openbook.openbook.booth.dto.BoothReservationDTO;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothArea;
@@ -46,6 +48,7 @@ public class ManagerBoothService {
     private final BoothReservationService boothReservationService;
     private final BoothReservationDetailService boothReservationDetailService;
     private final BoothProductService boothProductService;
+    private final BoothNoticeService boothNoticeService;
 
 
     @Transactional(readOnly = true)
@@ -98,6 +101,17 @@ public class ManagerBoothService {
         BoothReservation boothReservation = boothReservationService.createBoothReservation(
                 new BoothReservationDTO(request.content(), request.date()), booth);
         boothReservationDetailService.createReservationDetail(request.times(), boothReservation);
+    }
+
+    @Transactional
+    public void registerBoothNotice(Long userId, Long boothId, BoothNoticeRegisterRequest request){
+        Booth booth = boothService.getBoothOrException(boothId);
+        if(!booth.getManager().getId().equals(userId)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        boothNoticeService.createBoothNotice(new BoothNoticeDto(
+                request.title(), request.content(), s3Service.uploadFileAndGetUrl(request.image()), request.noticeType(), booth
+        ));
     }
 
     private Booth getValidBoothOrException(Long userId, Long boothId) {

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -6,15 +6,12 @@ import com.openbook.openbook.booth.controller.response.BoothAreaData;
 import com.openbook.openbook.booth.controller.response.BoothManageData;
 import com.openbook.openbook.booth.dto.BoothNoticeDto;
 import com.openbook.openbook.booth.dto.BoothReservationDTO;
-import com.openbook.openbook.booth.entity.Booth;
-import com.openbook.openbook.booth.entity.BoothArea;
-import com.openbook.openbook.booth.entity.BoothReservation;
+import com.openbook.openbook.booth.entity.*;
 import com.openbook.openbook.booth.entity.dto.BoothStatus;
 import com.openbook.openbook.booth.service.core.*;
 import com.openbook.openbook.booth.controller.request.ProductRegistrationRequest;
 
 import com.openbook.openbook.booth.dto.BoothProductDto;
-import com.openbook.openbook.booth.entity.BoothProduct;
 import com.openbook.openbook.booth.service.core.BoothAreaService;
 import com.openbook.openbook.booth.service.core.BoothProductService;
 import com.openbook.openbook.booth.service.core.BoothService;
@@ -106,7 +103,7 @@ public class ManagerBoothService {
     @Transactional
     public void registerBoothNotice(Long userId, Long boothId, BoothNoticeRegisterRequest request){
         Booth booth = boothService.getBoothOrException(boothId);
-        if(!booth.getManager().getId().equals(userId)){
+        if(!booth.getManager().getId().equals(userId) || !booth.getStatus().equals(BoothStatus.APPROVE)){
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         boothNoticeService.createBoothNotice(new BoothNoticeDto(

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
@@ -1,0 +1,25 @@
+package com.openbook.openbook.booth.service.core;
+
+import com.openbook.openbook.booth.dto.BoothNoticeDto;
+import com.openbook.openbook.booth.entity.BoothNotice;
+import com.openbook.openbook.booth.repository.BoothNoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoothNoticeService {
+    private final BoothNoticeRepository boothNoticeRepository;
+
+    public void createBoothNotice(BoothNoticeDto boothNoticeDto){
+        boothNoticeRepository.save(
+                BoothNotice.builder()
+                        .title(boothNoticeDto.title())
+                        .content(boothNoticeDto.content())
+                        .type(boothNoticeDto.type())
+                        .imageUrl(boothNoticeDto.imageUrl())
+                        .linkedBooth(boothNoticeDto.linkedBooth())
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #142

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothNoticeRegisterRequest를 생성해서 등록 데이터를 요청 받게 했습니다.
- BoothNoticeService와 BoothNoticeRepository를 만들어서 부스 공지글을 저장하게 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 테스트 결과
<img width="809" alt="image" src="https://github.com/user-attachments/assets/51b7b438-b0f1-4028-9921-4825280d7ccb">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 행사 공지 등록 흐름에 맞게 개발을 진행했습니다. 다만 승인된 부스만 공지 글을 올릴 수 있으면 좋을 것 같아 조건을 추가했습니다. 행사도 승인된 행사만 글을 올릴 수 있게 하는게 어떨까요?
- 추가 의견이나 질문 있으시면 코멘트 남겨주세요!