### PR TITLE
Feat: 부스 공지 목록 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.booth.controller;
 import com.openbook.openbook.booth.controller.request.BoothRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothBasicData;
 import com.openbook.openbook.booth.controller.response.BoothDetail;
+import com.openbook.openbook.booth.controller.response.BoothNoticeResponse;
 import com.openbook.openbook.booth.service.UserBoothService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
@@ -39,6 +40,11 @@ public class UserBoothController {
     @GetMapping("/{boothId}")
     public ResponseEntity<BoothDetail> getBooth(Authentication authentication, @PathVariable Long boothId){
         return ResponseEntity.ok(userBoothService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
+    }
+
+    @GetMapping("/{boothId}/notices")
+    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotice(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
+        return ResponseEntity.ok(SliceResponse.of(userBoothService.getBoothNotices(boothId, pageable)));
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothNoticeResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothNoticeResponse.java
@@ -1,0 +1,32 @@
+package com.openbook.openbook.booth.controller.response;
+
+import com.openbook.openbook.booth.entity.BoothNotice;
+import com.openbook.openbook.booth.entity.dto.BoothNoticeType;
+
+import java.time.LocalDateTime;
+
+public record BoothNoticeResponse(
+        long id,
+        String title,
+        String content,
+        String imageUrl,
+        BoothNoticeType type,
+        LocalDateTime registeredAt,
+        long boothId,
+        String boothName,
+        long boothManagerId
+) {
+    public static BoothNoticeResponse of(BoothNotice boothNotice){
+        return new BoothNoticeResponse(
+                boothNotice.getId(),
+                boothNotice.getTitle(),
+                boothNotice.getContent(),
+                boothNotice.getImageUrl(),
+                BoothNoticeType.valueOf(boothNotice.getType()),
+                boothNotice.getRegisteredAt(),
+                boothNotice.getLinkedBooth().getId(),
+                boothNotice.getLinkedBooth().getName(),
+                boothNotice.getLinkedBooth().getManager().getId()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothNoticeRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothNoticeRepository.java
@@ -1,7 +1,10 @@
 package com.openbook.openbook.booth.repository;
 
 import com.openbook.openbook.booth.entity.BoothNotice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoothNoticeRepository extends JpaRepository<BoothNotice, Long> {
+    Slice<BoothNotice> findByLinkedBoothIdOrderByRegisteredAtDesc(Long linkedBoothId, Pageable pageable);
 }

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothNoticeRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothNoticeRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoothNoticeRepository extends JpaRepository<BoothNotice, Long> {
-    Slice<BoothNotice> findByLinkedBoothIdOrderByRegisteredAtDesc(Long linkedBoothId, Pageable pageable);
+    Slice<BoothNotice> findByLinkedBoothId(Long linkedBoothId, Pageable pageable);
 }

--- a/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
@@ -5,12 +5,14 @@ import static com.openbook.openbook.global.util.Formatter.getDateTime;
 import com.openbook.openbook.booth.controller.request.BoothRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothBasicData;
 import com.openbook.openbook.booth.controller.response.BoothDetail;
+import com.openbook.openbook.booth.controller.response.BoothNoticeResponse;
 import com.openbook.openbook.booth.dto.BoothDTO;
 import com.openbook.openbook.booth.entity.dto.BoothStatus;
 import com.openbook.openbook.booth.dto.BoothTagDTO;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.dto.BoothAreaStatus;
 import com.openbook.openbook.booth.service.core.BoothAreaService;
+import com.openbook.openbook.booth.service.core.BoothNoticeService;
 import com.openbook.openbook.booth.service.core.BoothService;
 import com.openbook.openbook.booth.service.core.BoothTagService;
 import com.openbook.openbook.event.entity.Event;
@@ -42,6 +44,7 @@ public class UserBoothService {
 
     private final BoothService boothService;
     private final BoothTagService boothTagService;
+    private final BoothNoticeService boothNoticeService;
     private final EventService eventService;
     private final BoothAreaService boothAreaService;
     private final UserService userService;
@@ -103,6 +106,12 @@ public class UserBoothService {
                 .map(BoothAreaData::of)
                 .collect(Collectors.toList());
         return BoothDetail.of(booth, boothAreaData, boothTagService.getBoothTag(booth.getId()), Objects.equals(booth.getManager().getId(), userId));
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<BoothNoticeResponse> getBoothNotices(Long boothId, Pageable pageable){
+        Booth booth = boothService.getBoothOrException(boothId);
+        return boothNoticeService.getNotices(booth, pageable).map(BoothNoticeResponse::of);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
@@ -27,7 +27,7 @@ public class BoothNoticeService {
     }
 
     public Slice<BoothNotice> getNotices(Booth booth, Pageable pageable){
-        return boothNoticeRepository.findByLinkedBoothIdOrderByRegisteredAtDesc(booth.getId(), pageable);
+        return boothNoticeRepository.findByLinkedBoothId(booth.getId(), pageable);
     }
 
 }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
@@ -1,9 +1,12 @@
 package com.openbook.openbook.booth.service.core;
 
 import com.openbook.openbook.booth.dto.BoothNoticeDto;
+import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothNotice;
 import com.openbook.openbook.booth.repository.BoothNoticeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,4 +25,9 @@ public class BoothNoticeService {
                         .build()
         );
     }
+
+    public Slice<BoothNotice> getNotices(Booth booth, Pageable pageable){
+        return boothNoticeRepository.findByLinkedBoothIdOrderByRegisteredAtDesc(booth.getId(), pageable);
+    }
+
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #156 

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothNoticeResponse를 만들어서 응답할 부스 공지 목록들을 담았습니다.
- 경로: GET booths/{boothId}/notices 
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 응답
<img width="1155" alt="스크린샷 2024-08-23 오전 11 38 41" src="https://github.com/user-attachments/assets/3b046fb7-f7cf-4fbd-9859-185a06175364">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 부스 공지 목록을 찾을 때 최신 등록 날짜로 정렬해서 반환했는데 이부분에 대해서는 어떻게 생각하시는지 의견 궁금합니다!
- 다른 의견이나 질문있으시면 코멘트 남겨주세요!