### PR TITLE
Feat: 부스의 상품 카테고리 목록 조회 api

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -3,10 +3,12 @@ package com.openbook.openbook.booth.controller;
 import com.openbook.openbook.booth.controller.request.BoothRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothBasicData;
 import com.openbook.openbook.booth.controller.response.BoothDetail;
+import com.openbook.openbook.booth.controller.response.ProductCategoryResponse;
 import com.openbook.openbook.booth.service.UserBoothService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -47,5 +49,10 @@ public class UserBoothController {
                                                                          @RequestParam(value = "page", defaultValue = "0") int page,
                                                                          @RequestParam(value = "sort", defaultValue = "desc") String sort){
         return ResponseEntity.ok(SliceResponse.of(userBoothService.searchBoothBy(searchType, query, page, sort)));
+    }
+
+    @GetMapping("/{booth_id}/product-category")
+    public ResponseEntity<List<ProductCategoryResponse>> getProductCategory(@PathVariable Long booth_id) {
+        return ResponseEntity.ok(userBoothService.getProductCategoryResponseList(booth_id));
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/controller/response/ProductCategoryResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/ProductCategoryResponse.java
@@ -1,0 +1,18 @@
+package com.openbook.openbook.booth.controller.response;
+
+import com.openbook.openbook.booth.entity.BoothProductCategory;
+
+public record ProductCategoryResponse(
+        long id,
+        String name,
+        String description
+) {
+
+    public static ProductCategoryResponse of(BoothProductCategory category) {
+        return new ProductCategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothProductCategory.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothProductCategory.java
@@ -26,6 +26,8 @@ public class BoothProductCategory {
 
     private String name;
 
+    private String description;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Booth linkedBooth;
 
@@ -33,8 +35,9 @@ public class BoothProductCategory {
     private List<BoothProduct> boothProducts = new ArrayList<>();
 
     @Builder
-    public BoothProductCategory(String name, Booth linkedBooth) {
+    public BoothProductCategory(String name, String description, Booth linkedBooth) {
         this.name = name;
+        this.description = description;
         this.linkedBooth = linkedBooth;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothProductCategoryRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothProductCategoryRepository.java
@@ -2,9 +2,12 @@ package com.openbook.openbook.booth.repository;
 
 
 import com.openbook.openbook.booth.entity.BoothProductCategory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothProductCategoryRepository extends JpaRepository<BoothProductCategory, Long> {
+
+    List<BoothProductCategory> findAllByLinkedBoothId(Long linkedBoothId);
 }

--- a/src/main/java/com/openbook/openbook/booth/service/EventManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/EventManagerBoothService.java
@@ -73,7 +73,7 @@ public class EventManagerBoothService {
 
         if(boothStatus.equals(BoothStatus.APPROVE)){
             changeAreaStatus(boothAreas, BoothAreaStatus.COMPLETE);
-            boothProductService.createProductCategory("기본", booth);
+            boothProductService.createProductCategory("기본", "기본으로 생성되는 카테고리",booth);
             alarmService.createAlarm(user, booth.getManager(), AlarmType.BOOTH_APPROVED, booth.getName());
         } else if (boothStatus.equals(BoothStatus.REJECT)) {
             changeAreaStatus(boothAreas, BoothAreaStatus.EMPTY);

--- a/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/UserBoothService.java
@@ -5,12 +5,14 @@ import static com.openbook.openbook.global.util.Formatter.getDateTime;
 import com.openbook.openbook.booth.controller.request.BoothRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothBasicData;
 import com.openbook.openbook.booth.controller.response.BoothDetail;
+import com.openbook.openbook.booth.controller.response.ProductCategoryResponse;
 import com.openbook.openbook.booth.dto.BoothDTO;
 import com.openbook.openbook.booth.entity.dto.BoothStatus;
 import com.openbook.openbook.booth.dto.BoothTagDTO;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.dto.BoothAreaStatus;
 import com.openbook.openbook.booth.service.core.BoothAreaService;
+import com.openbook.openbook.booth.service.core.BoothProductService;
 import com.openbook.openbook.booth.service.core.BoothService;
 import com.openbook.openbook.booth.service.core.BoothTagService;
 import com.openbook.openbook.event.entity.Event;
@@ -47,6 +49,7 @@ public class UserBoothService {
     private final UserService userService;
     private final AlarmService alarmService;
     private final S3Service s3Service;
+    private final BoothProductService boothProductService;
 
     @Transactional
     public void boothRegistration(Long userId, BoothRegistrationRequest request){
@@ -121,6 +124,15 @@ public class UserBoothService {
     }
 
 
+    @Transactional(readOnly = true)
+    public List<ProductCategoryResponse> getProductCategoryResponseList(long boothId) {
+        Booth booth = boothService.getBoothOrException(boothId);
+        if(!booth.getStatus().equals(BoothStatus.APPROVE)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        return boothProductService.getProductCategories(booth).stream().map(ProductCategoryResponse::of).toList();
+    }
+
     private boolean hasReservationData(List<Long> eventLayoutAreaList){
         for(Long id : eventLayoutAreaList){
             BoothArea boothArea = boothAreaService.getBoothAreaOrException(id);
@@ -147,5 +159,6 @@ public class UserBoothService {
 
         return PageRequest.of(page, 6, Sort.by(direction, sortProperty));
     }
+
 
 }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -12,6 +12,7 @@ import com.openbook.openbook.booth.repository.BoothProductRepository;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.global.util.S3Service;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,10 +32,15 @@ public class BoothProductService {
         );
     }
 
-    public void createProductCategory(String categoryName, Booth linkedBooth) {
+    public List<BoothProductCategory> getProductCategories(final Booth linkedBooth) {
+        return categoryRepository.findAllByLinkedBoothId(linkedBooth.getId());
+    }
+
+    public void createProductCategory(String categoryName, String description, Booth linkedBooth) {
         categoryRepository.save(
                 BoothProductCategory.builder()
                         .name(categoryName)
+                        .description(description)
                         .linkedBooth(linkedBooth)
                         .build()
         );


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #154 

부스의 상품 카테고리 목록을 조회하는 api를 개발했습니다.
**API**: GET /booths/{booth_id}/product-category

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 기존 카테고리 엔티티에 설명 필드를 추가
- 부스 id를 통해 해당 부스의 상품 카테고리 list를 가져오는 기능

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공: /booths/70/product-category (200)
![image](https://github.com/user-attachments/assets/4bc618d2-2952-4239-8d63-41c60a8ec91d)

- 승인되지 않은 부스: /booths/90/product-category
![image](https://github.com/user-attachments/assets/9aec4a77-d8a7-4762-8914-b9b267f5cca4)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- api 엔드포인트에 관련해서 products/category 로 하려다가 상품들 상위에 카테고리가 있는 거라 하위로 두면 의미가 애매해질 것 같아서 "상품 카테고리" 라는 의미로 연결해 사용했습니다
- 카테고리는 추후 갯수 제한 등을 두는 건 어떤가 생각들기도 했고 그렇게 많지도 않을 것 같아서 pageable을 사용하지 않고 list로 반환되도록 구현했습니다 !
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃