### PR TITLE
Feat: 행사 공지사항 삭제 API

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/ManagerEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/ManagerEventController.java
@@ -12,6 +12,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,4 +41,12 @@ public class ManagerEventController {
         managerEventService.registerEventNotice(Long.valueOf(authentication.getName()), event_id, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
     }
+
+    @DeleteMapping("/events/notices/{notice_id}")
+    public ResponseEntity<ResponseMessage> deleteNotice(Authentication authentication,
+                                                        @PathVariable Long notice_id) {
+        managerEventService.deleteEventNotice(Long.valueOf(authentication.getName()), notice_id);
+        return ResponseEntity.ok(new ResponseMessage("공지 삭제에 성공했습니다."));
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/event/dto/EventNoticeDto.java
+++ b/src/main/java/com/openbook/openbook/event/dto/EventNoticeDto.java
@@ -2,11 +2,12 @@ package com.openbook.openbook.event.dto;
 
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.dto.EventNoticeType;
+import org.springframework.web.multipart.MultipartFile;
 
 public record EventNoticeDto(
         String title,
         String content,
-        String imageUrl,
+        MultipartFile image,
         EventNoticeType type,
         Event linkedEvent
 ) {

--- a/src/main/java/com/openbook/openbook/event/service/ManagerEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/ManagerEventService.java
@@ -4,6 +4,7 @@ import com.openbook.openbook.event.controller.request.EventNoticeRegisterRequest
 import com.openbook.openbook.event.controller.response.ManagerEventData;
 import com.openbook.openbook.event.dto.EventNoticeDto;
 import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.EventNotice;
 import com.openbook.openbook.event.entity.dto.EventStatus;
 import com.openbook.openbook.event.service.core.EventNoticeService;
 import com.openbook.openbook.event.service.core.EventService;
@@ -49,6 +50,15 @@ public class ManagerEventService {
                 request.title(), request.content(), request.image(),
                 request.noticeType(), event)
         );
+    }
+
+    @Transactional
+    public void deleteEventNotice(Long userId, Long noticeId) {
+        EventNotice eventNotice = eventNoticeService.getEventNoticeOrException(noticeId);
+        if (!eventNotice.getLinkedEvent().getManager().getId().equals(userId)) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        eventNoticeService.deleteEventNotice(eventNotice);
     }
 
 }

--- a/src/main/java/com/openbook/openbook/event/service/ManagerEventService.java
+++ b/src/main/java/com/openbook/openbook/event/service/ManagerEventService.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ManagerEventService {
 
-    private final S3Service service;
     private final UserService userService;
     private final EventService eventService;
     private final EventTagService eventTagService;
@@ -47,7 +46,7 @@ public class ManagerEventService {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         eventNoticeService.createEventNotice(new EventNoticeDto(
-                request.title(), request.content(), service.uploadFileAndGetUrl(request.image()),
+                request.title(), request.content(), request.image(),
                 request.noticeType(), event)
         );
     }

--- a/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
@@ -7,6 +7,7 @@ import com.openbook.openbook.event.entity.EventNotice;
 import com.openbook.openbook.event.repository.EventNoticeRepository;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.global.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class EventNoticeService {
 
     private final EventNoticeRepository eventNoticeRepository;
+    private final S3Service s3Service;
 
     public EventNotice getEventNoticeOrException(final Long id) {
         return eventNoticeRepository.findById(id).orElseThrow(() ->
@@ -30,7 +32,7 @@ public class EventNoticeService {
                         .title(eventNoticeDto.title())
                         .content(eventNoticeDto.content())
                         .type(eventNoticeDto.type())
-                        .imageUrl(eventNoticeDto.imageUrl())
+                        .imageUrl(s3Service.uploadFileAndGetUrl(eventNoticeDto.image()))
                         .linkedEvent(eventNoticeDto.linkedEvent())
                         .build()
         );

--- a/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventNoticeService.java
@@ -42,4 +42,9 @@ public class EventNoticeService {
         return eventNoticeRepository.findByLinkedEventId(event.getId(), pageable);
     }
 
+    public void deleteEventNotice(EventNotice notice) {
+        s3Service.deleteFileFromS3(notice.getImageUrl());
+        eventNoticeRepository.delete(notice);
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/global/util/S3Service.java
+++ b/src/main/java/com/openbook/openbook/global/util/S3Service.java
@@ -19,6 +19,7 @@ public class S3Service {
     @Value("${aws.s3.bucket.name}")
     private String bucket;
     private final AmazonS3Client S3Client;
+    private final int S3_PATH_LENGTH = 55;
 
     public String uploadFileAndGetUrl(final MultipartFile file) {
         ObjectMetadata metadata = new ObjectMetadata();
@@ -35,8 +36,8 @@ public class S3Service {
         return getFileUrlFromS3(fileName);
     }
 
-    public void deleteFileFromS3(final String fileName){
-        S3Client.deleteObject(bucket, fileName);
+    public void deleteFileFromS3(final String fileUrl){
+        S3Client.deleteObject(bucket, fileUrl.substring(S3_PATH_LENGTH));
     }
 
     private String getFileUrlFromS3(final String fileName) {


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #165 

행사의 공지사항을 삭제하는 API를 개발했습니다.
- **API** DELETE /events/notices/{notice_id}

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 기존 공지 생성 시 파일을 url로 변환하는 과정의 위치를 core 서비스에서 하도록 변경
- 이미지 삭제를 위한 url에서 name 만 빼내는 작업을 S3에서 바로 하도록 변경

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
DELETE {{local}}/events/notices/2 요청으로 테스트했습니다.

- 성공
![image](https://github.com/user-attachments/assets/4891f93f-c7f9-4aa8-a353-7a97a61b9ff2)


[S3 이미지 삭제 확인]
- 삭제 전 최신순
![image](https://github.com/user-attachments/assets/0ed8a90c-a60e-4564-abfb-829f390e37d8)
- 삭제 후 최신순
![image](https://github.com/user-attachments/assets/928c94ca-cb8f-4b7c-b504-14281ece2a8e)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 해당 행사가 승인 됐는지는 생성할 때 확인하기 때문에 삭제 시에는 권한만 확인하도록 구현했습니다!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃