### PR TITLE
Refactor: 부스 예약 필드 추가 및 저장

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/request/ReserveRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/request/ReserveRegistrationRequest.java
@@ -12,9 +12,9 @@ import java.util.List;
 public record ReserveRegistrationRequest(
         @NotBlank String name,
         @NotBlank String description,
-        @NotNull LocalDate date,
-        @NotEmpty List<String> times,
+        @NotNull int price,
         MultipartFile image,
-        @NotNull int price
+        @NotNull LocalDate date,
+        @NotEmpty List<String> times
         ) {
 }

--- a/src/main/java/com/openbook/openbook/booth/controller/request/ReserveRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/request/ReserveRegistrationRequest.java
@@ -3,13 +3,18 @@ package com.openbook.openbook.booth.controller.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public record ReserveRegistrationRequest(
-        @NotBlank String content,
+        @NotBlank String name,
+        @NotBlank String description,
         @NotNull LocalDate date,
-        @NotEmpty List<String> times
+        @NotEmpty List<String> times,
+        MultipartFile image,
+        @NotNull int price
         ) {
 }

--- a/src/main/java/com/openbook/openbook/booth/dto/BoothReservationDTO.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/BoothReservationDTO.java
@@ -1,9 +1,14 @@
 package com.openbook.openbook.booth.dto;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import java.time.LocalDate;
 
 public record BoothReservationDTO(
-        String content,
-        LocalDate date
+        String name,
+        String description,
+        LocalDate date,
+        MultipartFile image,
+        int price
 ) {
 }

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservation.java
@@ -18,9 +18,15 @@ public class BoothReservation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String content;
+    private String name;
+
+    private String description;
 
     private LocalDate date;
+
+    private String imageUrl;
+
+    private int price;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Booth linkedBooth;
@@ -29,9 +35,12 @@ public class BoothReservation {
     private List<BoothReservationDetail> boothReservationDetails = new ArrayList<>();
 
     @Builder
-    public BoothReservation(Booth linkedBooth, String content, LocalDate date){
-        this.content = content;
+    public BoothReservation(String name, String description, Booth linkedBooth, LocalDate date, String imageUrl, int price){
+        this.name = name;
+        this.description = description;
         this.date = date;
+        this.imageUrl = imageUrl;
+        this.price = price;
         this.linkedBooth = linkedBooth;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -110,7 +110,8 @@ public class ManagerBoothService {
         checkAvailableTime(request, booth);
         checkDuplicateTimes(request.times());
         BoothReservation boothReservation = boothReservationService.createBoothReservation(
-                new BoothReservationDTO(request.content(), request.date()), booth);
+                new BoothReservationDTO(request.name(), request.description(), request.date(),
+                        request.image(), request.price()), booth);
         boothReservationDetailService.createReservationDetail(request.times(), boothReservation);
     }
 

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationService.java
@@ -4,6 +4,7 @@ import com.openbook.openbook.booth.dto.BoothReservationDTO;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothReservation;
 import com.openbook.openbook.booth.repository.BoothReservationRepository;
+import com.openbook.openbook.global.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +14,14 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class BoothReservationService {
     private final BoothReservationRepository boothReservationRepository;
+    private final S3Service s3Service;
     public BoothReservation createBoothReservation(BoothReservationDTO boothReservationDTO, Booth booth){
         return boothReservationRepository.save(
                 BoothReservation.builder()
-                        .content(boothReservationDTO.content())
+                        .name(boothReservationDTO.name())
+                        .description(boothReservationDTO.description())
                         .date(boothReservationDTO.date())
+                        .imageUrl(s3Service.uploadFileAndGetUrl(boothReservationDTO.image()))
                         .linkedBooth(booth)
                         .build()
         );


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #167

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스 예약 등록시 필요한 데이터가 추가 및 변동 되었습니다. 
title, description, date, times, price, image
- 이때 image를 제외한 모든 값은 필수로 설정했습니다.
- db table에도 동일하게 칼럼을 추가 및 수정했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 저장 요청 후
<img width="827" alt="image" src="https://github.com/user-attachments/assets/e491864a-b3bc-4929-9680-72c8d6241b55">

booth_reservation table
<img width="601" alt="image" src="https://github.com/user-attachments/assets/81fa1514-bc8d-476a-91d3-4c294f36512a">

booth_reservation_detail table
<img width="395" alt="image" src="https://github.com/user-attachments/assets/e8605f62-0664-4da0-be4f-95959b408a19">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 이미지는 필수적으로 저장하지 않아도 될 것 같다는 판단이 들어 우선 빼고 개발 진행했습니다. 또 이미지는 한개의 이미지만 저장하게 구현했습니다. 이부분에 대해서는 회의를 통해 다시 결정해도 좋을 것 같습니다.
- 이미지가 필수 값이 아니기 때문에 빈 값을 보낼 수가 있는데 그렇게 됐을 경우에도 s3 url 이 생성되어 만들어지는데 이 부분에 대해서도 추후 리팩토링 작업을 진행하면 좋을 것 같습니다!
- 그 외에 추가 질문이나 의견있으시면 리뷰 남겨주세요!