### PR TITLE
Fix: 부스 태그 검색시 기본 값 반환 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -56,7 +56,7 @@ public class UserBoothController {
 
     @GetMapping("/search")
     public ResponseEntity<SliceResponse<BoothBasicData>> searchBoothName(@RequestParam(value = "type") String searchType,
-                                                                         @RequestParam(value = "query") String query,
+                                                                         @RequestParam(value = "query", defaultValue = "") String query,
                                                                          @RequestParam(value = "page", defaultValue = "0") int page,
                                                                          @RequestParam(value = "sort", defaultValue = "desc") String sort){
         return ResponseEntity.ok(SliceResponse.of(boothCommonService.searchBoothBy(searchType, query, page, sort)));

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
@@ -16,6 +16,6 @@ public interface BoothTagRepository extends JpaRepository<BoothTag, Long> {
     @Query("SELECT t FROM BoothTag t WHERE t.linkedBooth.id=:boothId")
     List<BoothTag> findAllByLinkedBoothId(Long boothId);
 
-    @Query("SELECT bt.linkedBooth FROM BoothTag bt WHERE bt.name LIKE :name AND bt.linkedBooth.status=:boothStatus")
-    Slice<Booth> findBoothByName(Pageable pageable, String name, BoothStatus boothStatus);
+    @Query("SELECT bt.linkedBooth FROM BoothTag bt WHERE bt.name LIKE %:name% AND bt.linkedBooth.status=:boothStatus")
+    Slice<Booth> findAllBoothByName(Pageable pageable, String name, BoothStatus boothStatus);
 }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothTagService.java
@@ -30,6 +30,6 @@ public class BoothTagService {
     }
 
     public Slice<Booth> getBoothByTag(Pageable pageable, String boothTag, BoothStatus status){
-        return boothTagRepository.findBoothByName(pageable, boothTag, status);
+        return boothTagRepository.findAllBoothByName(pageable, boothTag, status);
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #171

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- query 파라미터의 defaultValue 값을 "" 로 지정했습니다.
- tag 데이터를 찾는 쿼리문에서 %를 추가했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
query 파라미터를 제외 했을 경우 나오는 결과
![스크린샷 2024-08-27 오후 7 53 56](https://github.com/user-attachments/assets/05ac8c5c-bb46-472f-a7a6-d7884c051c71)
![스크린샷 2024-08-27 오후 7 54 08](https://github.com/user-attachments/assets/3d70ca1f-2ea5-4656-b97f-ea750d5dbcec)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 다른 수정사항이나 의견 있으시면 말씀해주세요!