### PR TITLE
Fix: 부스 검색 중복 값 제거

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,7 +60,8 @@ public class UserBoothController {
                                                                          @RequestParam(value = "query", defaultValue = "") String query,
                                                                          @RequestParam(value = "page", defaultValue = "0") int page,
                                                                          @RequestParam(value = "sort", defaultValue = "desc") String sort){
-        return ResponseEntity.ok(SliceResponse.of(boothCommonService.searchBoothBy(searchType, query, page, sort)));
+        Slice<BoothBasicData> result = boothCommonService.searchBoothBy(searchType, query, page, sort);
+        return ResponseEntity.ok(SliceResponse.of(result));
     }
 
     @GetMapping("/{booth_id}/product-category")

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothTagRepository.java
@@ -16,6 +16,6 @@ public interface BoothTagRepository extends JpaRepository<BoothTag, Long> {
     @Query("SELECT t FROM BoothTag t WHERE t.linkedBooth.id=:boothId")
     List<BoothTag> findAllByLinkedBoothId(Long boothId);
 
-    @Query("SELECT bt.linkedBooth FROM BoothTag bt WHERE bt.name LIKE %:name% AND bt.linkedBooth.status=:boothStatus")
+    @Query("SELECT distinct bt.linkedBooth FROM BoothTag bt WHERE bt.name LIKE %:name% AND bt.linkedBooth.status=:boothStatus")
     Slice<Booth> findAllBoothByName(Pageable pageable, String name, BoothStatus boothStatus);
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #173 
- 부스 검색 시 데이터가 한페이지에 5개로 나오지 않는 문제를 해결했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 쿼리문에 중복되는 태그 데이터 제거하는 distinct 조건 추가
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 검색했을 때 결과 값
![image](https://github.com/user-attachments/assets/acf630cf-dcf2-4007-89d1-7638dc9a0e36)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 혹시 다른 문제점을 놓친게 있다면 말씀 해주세요 😊