### PR TITLE
Feat: 부스의 상품을 카테고리 별로 조회하는 API

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -31,7 +31,6 @@ public class UserBoothController {
     @PostMapping
     public ResponseEntity <ResponseMessage>  registration(Authentication authentication, @Valid BoothRegistrationRequest request){
         userBoothService.boothRegistration(Long.valueOf(authentication.getName()), request);
-
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(new ResponseMessage("신청 완료 되었습니다."));
@@ -49,7 +48,8 @@ public class UserBoothController {
     }
 
     @GetMapping("/{boothId}/notices")
-    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotice(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
+    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotice(@PathVariable Long boothId,
+                                                                             @PageableDefault(size = 5) Pageable pageable){
         return ResponseEntity.ok(SliceResponse.of(userBoothService.getBoothNotices(boothId, pageable)));
     }
 

--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -48,15 +48,15 @@ public class UserBoothController {
     public ResponseEntity<BoothDetail> getBooth(Authentication authentication, @PathVariable Long boothId){
         return ResponseEntity.ok(boothCommonService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
     }
+    
+    @GetMapping("/{boothId}/notices")
+    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotices(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
+        return ResponseEntity.ok(SliceResponse.of(boothCommonService.getBoothNotices(boothId, pageable)));
+    }
 
     @GetMapping("/notices/{noticeId}")
     public ResponseEntity<BoothNoticeResponse> getBoothNotice(@PathVariable Long noticeId){
         return ResponseEntity.ok(boothCommonService.getBoothNotice(noticeId));
-    }
-
-    @GetMapping("/{boothId}/notices")
-    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotices(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
-        return ResponseEntity.ok(SliceResponse.of(boothCommonService.getBoothNotices(boothId, pageable)));
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -3,9 +3,11 @@ package com.openbook.openbook.booth.controller;
 import com.openbook.openbook.booth.controller.request.BoothRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothBasicData;
 import com.openbook.openbook.booth.controller.response.BoothDetail;
+import com.openbook.openbook.booth.controller.response.CategoryProducts;
 import com.openbook.openbook.booth.controller.response.ProductCategoryResponse;
 import com.openbook.openbook.booth.controller.response.BoothNoticeResponse;
 import com.openbook.openbook.booth.service.UserBoothService;
+import com.openbook.openbook.booth.service.common.CommonProductService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
@@ -24,6 +26,8 @@ import org.springframework.web.bind.annotation.*;
 public class UserBoothController {
 
     private final UserBoothService userBoothService;
+    private final CommonProductService commonProductService;
+
     @PostMapping
     public ResponseEntity <ResponseMessage>  registration(Authentication authentication, @Valid BoothRegistrationRequest request){
         userBoothService.boothRegistration(Long.valueOf(authentication.getName()), request);
@@ -61,4 +65,11 @@ public class UserBoothController {
     public ResponseEntity<List<ProductCategoryResponse>> getProductCategory(@PathVariable Long booth_id) {
         return ResponseEntity.ok(userBoothService.getProductCategoryResponseList(booth_id));
     }
+
+    @GetMapping("/{booth_id}/products")
+    public ResponseEntity<List<CategoryProducts>> getAllProductsBy(@PathVariable Long booth_id,
+                                                                   @PageableDefault(size = 5) Pageable pageable) {
+        return ResponseEntity.ok(commonProductService.findAllBoothProducts(booth_id, pageable));
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,17 +49,23 @@ public class UserBoothController {
         return ResponseEntity.ok(boothCommonService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
     }
 
+    @GetMapping("/notices/{noticeId}")
+    public ResponseEntity<BoothNoticeResponse> getBoothNotice(@PathVariable Long noticeId){
+        return ResponseEntity.ok(boothCommonService.getBoothNotice(noticeId));
+    }
+
     @GetMapping("/{boothId}/notices")
-    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotice(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
+    public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotices(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
         return ResponseEntity.ok(SliceResponse.of(boothCommonService.getBoothNotices(boothId, pageable)));
     }
 
     @GetMapping("/search")
     public ResponseEntity<SliceResponse<BoothBasicData>> searchBoothName(@RequestParam(value = "type") String searchType,
-                                                                         @RequestParam(value = "query") String query,
+                                                                         @RequestParam(value = "query", defaultValue = "") String query,
                                                                          @RequestParam(value = "page", defaultValue = "0") int page,
                                                                          @RequestParam(value = "sort", defaultValue = "desc") String sort){
-        return ResponseEntity.ok(SliceResponse.of(boothCommonService.searchBoothBy(searchType, query, page, sort)));
+        Slice<BoothBasicData> result = boothCommonService.searchBoothBy(searchType, query, page, sort);
+        return ResponseEntity.ok(SliceResponse.of(result));
     }
 
     @GetMapping("/{booth_id}/product-category")

--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -3,7 +3,7 @@ package com.openbook.openbook.booth.controller;
 import com.openbook.openbook.booth.controller.request.BoothRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothBasicData;
 import com.openbook.openbook.booth.controller.response.BoothDetail;
-import com.openbook.openbook.booth.controller.response.CategoryProducts;
+import com.openbook.openbook.booth.controller.response.CategoryProductsResponse;
 import com.openbook.openbook.booth.controller.response.ProductCategoryResponse;
 import com.openbook.openbook.booth.controller.response.BoothNoticeResponse;
 import com.openbook.openbook.booth.service.BoothCommonService;
@@ -48,7 +48,7 @@ public class UserBoothController {
     public ResponseEntity<BoothDetail> getBooth(Authentication authentication, @PathVariable Long boothId){
         return ResponseEntity.ok(boothCommonService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
     }
-    
+
     @GetMapping("/{boothId}/notices")
     public ResponseEntity<SliceResponse<BoothNoticeResponse>> getBoothNotices(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
         return ResponseEntity.ok(SliceResponse.of(boothCommonService.getBoothNotices(boothId, pageable)));
@@ -74,8 +74,8 @@ public class UserBoothController {
     }
 
     @GetMapping("/{booth_id}/products")
-    public ResponseEntity<List<CategoryProducts>> getAllProductsBy(@PathVariable Long booth_id,
-                                                                   @PageableDefault(size = 5) Pageable pageable) {
+    public ResponseEntity<List<CategoryProductsResponse>> getAllProductsBy(@PathVariable Long booth_id,
+                                                                           @PageableDefault(size = 5) Pageable pageable) {
         return ResponseEntity.ok(commonProductService.findAllBoothProducts(booth_id, pageable));
     }
 

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothProductResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothProductResponse.java
@@ -1,21 +1,26 @@
 package com.openbook.openbook.booth.controller.response;
 
+import com.openbook.openbook.booth.dto.ProductImageDto;
 import com.openbook.openbook.booth.entity.BoothProduct;
+import com.openbook.openbook.booth.entity.BoothProductImage;
+import java.util.List;
 
 public record BoothProductResponse(
         long id,
         String name,
         String description,
         int stock,
-        int price
+        int price,
+        List<ProductImageDto> images
 ) {
-    public static BoothProductResponse of(final BoothProduct product) {
+    public static BoothProductResponse of(final BoothProduct product, List<BoothProductImage> images) {
         return new BoothProductResponse(
                 product.getId(),
                 product.getName(),
                 product.getDescription(),
                 product.getStock(),
-                product.getPrice()
+                product.getPrice(),
+                images.stream().map(ProductImageDto::of).toList()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothProductResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothProductResponse.java
@@ -1,0 +1,21 @@
+package com.openbook.openbook.booth.controller.response;
+
+import com.openbook.openbook.booth.entity.BoothProduct;
+
+public record BoothProductResponse(
+        long id,
+        String name,
+        String description,
+        int stock,
+        int price
+) {
+    public static BoothProductResponse of(final BoothProduct product) {
+        return new BoothProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getStock(),
+                product.getPrice()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/controller/response/CategoryProducts.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/CategoryProducts.java
@@ -1,0 +1,20 @@
+package com.openbook.openbook.booth.controller.response;
+
+import com.openbook.openbook.booth.entity.BoothProduct;
+import com.openbook.openbook.booth.entity.BoothProductCategory;
+import com.openbook.openbook.global.dto.SliceResponse;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+@Builder
+public record CategoryProducts(
+        ProductCategoryResponse category,
+        SliceResponse<BoothProductResponse> products
+) {
+    public static CategoryProducts of(BoothProductCategory category, Slice<BoothProduct> products) {
+        return new CategoryProducts(
+                ProductCategoryResponse.of(category),
+                SliceResponse.of(products.map(BoothProductResponse::of))
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/controller/response/CategoryProducts.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/CategoryProducts.java
@@ -11,10 +11,10 @@ public record CategoryProducts(
         ProductCategoryResponse category,
         SliceResponse<BoothProductResponse> products
 ) {
-    public static CategoryProducts of(BoothProductCategory category, Slice<BoothProduct> products) {
+    public static CategoryProducts of(BoothProductCategory category, Slice<BoothProductResponse> products) {
         return new CategoryProducts(
                 ProductCategoryResponse.of(category),
-                SliceResponse.of(products.map(BoothProductResponse::of))
+                SliceResponse.of(products)
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/controller/response/CategoryProductsResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/CategoryProductsResponse.java
@@ -1,18 +1,17 @@
 package com.openbook.openbook.booth.controller.response;
 
-import com.openbook.openbook.booth.entity.BoothProduct;
 import com.openbook.openbook.booth.entity.BoothProductCategory;
 import com.openbook.openbook.global.dto.SliceResponse;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
 @Builder
-public record CategoryProducts(
+public record CategoryProductsResponse(
         ProductCategoryResponse category,
         SliceResponse<BoothProductResponse> products
 ) {
-    public static CategoryProducts of(BoothProductCategory category, Slice<BoothProductResponse> products) {
-        return new CategoryProducts(
+    public static CategoryProductsResponse of(BoothProductCategory category, Slice<BoothProductResponse> products) {
+        return new CategoryProductsResponse(
                 ProductCategoryResponse.of(category),
                 SliceResponse.of(products)
         );

--- a/src/main/java/com/openbook/openbook/booth/dto/ProductImageDto.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/ProductImageDto.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.booth.dto;
+
+import com.openbook.openbook.booth.entity.BoothProductImage;
+
+public record ProductImageDto(
+        long id,
+        String url
+) {
+    public static ProductImageDto of(BoothProductImage image) {
+        return new ProductImageDto(
+                image.getId(),
+                image.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothProductImageRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothProductImageRepository.java
@@ -1,7 +1,11 @@
 package com.openbook.openbook.booth.repository;
 
 import com.openbook.openbook.booth.entity.BoothProductImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoothProductImageRepository extends JpaRepository<BoothProductImage, Long> {
+
+    List<BoothProductImage> findAllByLinkedProductId(Long linkedProductId);
+
 }

--- a/src/main/java/com/openbook/openbook/booth/repository/BoothProductRepository.java
+++ b/src/main/java/com/openbook/openbook/booth/repository/BoothProductRepository.java
@@ -1,7 +1,12 @@
 package com.openbook.openbook.booth.repository;
 
 import com.openbook.openbook.booth.entity.BoothProduct;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoothProductRepository extends JpaRepository<BoothProduct, Long> {
+
+    Slice<BoothProduct> findAllByLinkedCategoryId(Long linkedCategoryId, Pageable pageable);
+
 }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonProductService.java
@@ -1,0 +1,38 @@
+package com.openbook.openbook.booth.service.common;
+
+import com.openbook.openbook.booth.controller.response.CategoryProducts;
+import com.openbook.openbook.booth.entity.Booth;
+import com.openbook.openbook.booth.entity.BoothProduct;
+import com.openbook.openbook.booth.entity.BoothProductCategory;
+import com.openbook.openbook.booth.service.core.BoothProductService;
+import com.openbook.openbook.booth.service.core.BoothService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommonProductService {
+
+    private final BoothService boothService;
+    private final BoothProductService boothProductService;
+
+    @Transactional(readOnly = true)
+    public List<CategoryProducts> findAllBoothProducts(final long boothId, final Pageable pageable) {
+        Booth booth = boothService.getBoothOrException(boothId);
+        List<BoothProductCategory> categories = boothProductService.getProductCategories(booth);
+        List<CategoryProducts> productsList = new ArrayList<>();
+        for(BoothProductCategory category : categories) {
+            Slice<BoothProduct> products = boothProductService.getProductsByCategory(category, pageable);
+            if(products.getNumberOfElements()!=0) {
+                productsList.add(CategoryProducts.of(category, products));
+            }
+        }
+        return productsList;
+    }
+
+}

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonProductService.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.booth.service.common;
 
+import com.openbook.openbook.booth.controller.response.BoothProductResponse;
 import com.openbook.openbook.booth.controller.response.CategoryProducts;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothProduct;
@@ -27,7 +28,12 @@ public class CommonProductService {
         List<BoothProductCategory> categories = boothProductService.getProductCategories(booth);
         List<CategoryProducts> productsList = new ArrayList<>();
         for(BoothProductCategory category : categories) {
-            Slice<BoothProduct> products = boothProductService.getProductsByCategory(category, pageable);
+            Slice<BoothProductResponse> products = boothProductService.getProductsByCategory(category, pageable).map(
+                    boothProduct -> BoothProductResponse.of(
+                            boothProduct,
+                            boothProductService.getProductImages(boothProduct)
+                    )
+            );
             if(products.getNumberOfElements()!=0) {
                 productsList.add(CategoryProducts.of(category, products));
             }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonProductService.java
@@ -1,9 +1,8 @@
 package com.openbook.openbook.booth.service.common;
 
 import com.openbook.openbook.booth.controller.response.BoothProductResponse;
-import com.openbook.openbook.booth.controller.response.CategoryProducts;
+import com.openbook.openbook.booth.controller.response.CategoryProductsResponse;
 import com.openbook.openbook.booth.entity.Booth;
-import com.openbook.openbook.booth.entity.BoothProduct;
 import com.openbook.openbook.booth.entity.BoothProductCategory;
 import com.openbook.openbook.booth.service.core.BoothProductService;
 import com.openbook.openbook.booth.service.core.BoothService;
@@ -23,10 +22,10 @@ public class CommonProductService {
     private final BoothProductService boothProductService;
 
     @Transactional(readOnly = true)
-    public List<CategoryProducts> findAllBoothProducts(final long boothId, final Pageable pageable) {
+    public List<CategoryProductsResponse> findAllBoothProducts(final long boothId, final Pageable pageable) {
         Booth booth = boothService.getBoothOrException(boothId);
         List<BoothProductCategory> categories = boothProductService.getProductCategories(booth);
-        List<CategoryProducts> productsList = new ArrayList<>();
+        List<CategoryProductsResponse> productsList = new ArrayList<>();
         for(BoothProductCategory category : categories) {
             Slice<BoothProductResponse> products = boothProductService.getProductsByCategory(category, pageable).map(
                     boothProduct -> BoothProductResponse.of(
@@ -35,7 +34,7 @@ public class CommonProductService {
                     )
             );
             if(products.getNumberOfElements()!=0) {
-                productsList.add(CategoryProducts.of(category, products));
+                productsList.add(CategoryProductsResponse.of(category, products));
             }
         }
         return productsList;

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -42,6 +42,10 @@ public class BoothProductService {
         return boothProductRepository.findAllByLinkedCategoryId(category.getId(), pageable);
     }
 
+    public List<BoothProductImage> getProductImages(final BoothProduct product) {
+        return boothProductImageRepository.findAllByLinkedProductId(product.getId());
+    }
+
     public boolean isExistsCategoryIn(Booth linkedBooth, String name) {
         return categoryRepository.existsByLinkedBoothIdAndName(linkedBooth.getId(), name);
     }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothProductService.java
@@ -14,6 +14,8 @@ import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.global.util.S3Service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,6 +36,10 @@ public class BoothProductService {
 
     public List<BoothProductCategory> getProductCategories(final Booth linkedBooth) {
         return categoryRepository.findAllByLinkedBoothId(linkedBooth.getId());
+    }
+
+    public Slice<BoothProduct> getProductsByCategory(final BoothProductCategory category, final Pageable pageable) {
+        return boothProductRepository.findAllByLinkedCategoryId(category.getId(), pageable);
     }
 
     public boolean isExistsCategoryIn(Booth linkedBooth, String name) {


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #144 

부스의 모든 상품을 카테고리로 묶어 조회하는 API 를 개발했습니다.
- **API**: GET /booths/{booth_id}/products

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 객체 추가
  - CategoryProductsResponse: 카테고리 별 상품들 응답 객체
  - BoothProductResponse: 부스 상품 정보 응답 객체
  - ProductImageDto: 상품 이미지 정보를 담을 객체
- commond 패키지를 추가, 하위에 commondProductService 를 추가해 구현

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 (200)
![image](https://github.com/user-attachments/assets/579332c1-dbb7-4af4-81e3-b3ef53890a37)
  - 카테고리가 더 있어도 상품이 없는 카테고리는 응답에 포함하지 않습니다.



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 최대 보이는 상품 수는 일단은 5개로 했습니다! 해당 건은 회의 때 의견 제시해볼게요!
- 부스의 CommonService 코드 양이 너무 많아 일단 해당 메서드를 CommonProductService 로 분리해 구현했는데, 괜찮으시면 common 패키지 하위에 도메인 별로 서비스를 나눠볼까 하는데 어떻게 생각하실까요?! 만약 괜찮으면 해당 건은 이슈를 따로 작성해 리팩터링 할까 합니다! 😃
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃