### PR TITLE
Refactor: 부스 공지 사진 업로드 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/dto/BoothNoticeDto.java
+++ b/src/main/java/com/openbook/openbook/booth/dto/BoothNoticeDto.java
@@ -2,11 +2,12 @@ package com.openbook.openbook.booth.dto;
 
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.dto.BoothNoticeType;
+import org.springframework.web.multipart.MultipartFile;
 
 public record BoothNoticeDto(
         String title,
         String content,
-        String imageUrl,
+        MultipartFile imageUrl,
         BoothNoticeType type,
         Booth linkedBooth
 ) {

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ManagerBoothService {
-    private final S3Service s3Service;
     private final UserService userService;
     private final BoothService boothService;
     private final BoothTagService boothTagService;
@@ -122,7 +121,7 @@ public class ManagerBoothService {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         boothNoticeService.createBoothNotice(new BoothNoticeDto(
-                request.title(), request.content(), s3Service.uploadFileAndGetUrl(request.image()), request.noticeType(), booth
+                request.title(), request.content(), request.image(), request.noticeType(), booth
         ));
     }
 

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothNoticeService.java
@@ -6,6 +6,7 @@ import com.openbook.openbook.booth.entity.BoothNotice;
 import com.openbook.openbook.booth.repository.BoothNoticeRepository;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.global.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class BoothNoticeService {
     private final BoothNoticeRepository boothNoticeRepository;
+    private final S3Service s3Service;
 
     public void createBoothNotice(BoothNoticeDto boothNoticeDto){
         boothNoticeRepository.save(
@@ -22,7 +24,7 @@ public class BoothNoticeService {
                         .title(boothNoticeDto.title())
                         .content(boothNoticeDto.content())
                         .type(boothNoticeDto.type())
-                        .imageUrl(boothNoticeDto.imageUrl())
+                        .imageUrl(s3Service.uploadFileAndGetUrl(boothNoticeDto.imageUrl()))
                         .linkedBooth(boothNoticeDto.linkedBooth())
                         .build()
         );


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #169 
- 부스 공지 사진을 s3에 저장할 때 요청 받은 이미지를 url 변환하는 과정의 위치 수정 했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothNoticeDto 의 image 필드 데이터 타입을 String에서 multipartFile로 변경했습니다.
- url 변환하는 과정을 boothNoticeService에서 구현
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 코드 수정후 공지 등록 테스트
![image](https://github.com/user-attachments/assets/3ff06a85-5d63-4517-a4f1-f5f16292db7d)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 저번에 공지 삭제 하신 pr 내역 보고 리팩토링 작업을 했습니다. 기타 수정사항이나 질문 있으시면 말씀해주세요!