### PR TITLE
Feat: 행사 리뷰 등록 API

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -69,7 +69,7 @@ public class UserEventController {
     }
 
 
-    @PostMapping("/event/reviews")
+    @PostMapping("/event/review")
     public ResponseEntity<ResponseMessage> postReview(Authentication authentication,
                                                       @Valid EventReviewRegisterRequest request) {
         eventReviewService.registerEventReview(Long.valueOf(authentication.getName()), request);

--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -70,7 +70,8 @@ public class UserEventController {
 
 
     @PostMapping("/event/reviews")
-    public ResponseEntity<ResponseMessage> postReview(Authentication authentication, @Valid EventReviewRegisterRequest request) {
+    public ResponseEntity<ResponseMessage> postReview(Authentication authentication,
+                                                      @Valid EventReviewRegisterRequest request) {
         eventReviewService.registerEventReview(Long.valueOf(authentication.getName()), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("행사 리뷰 작성에 성공했습니다."));
     }

--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -1,10 +1,12 @@
 package com.openbook.openbook.event.controller;
 
 
+import com.openbook.openbook.event.controller.request.EventReviewRegisterRequest;
 import com.openbook.openbook.event.controller.response.EventNoticeData;
 import com.openbook.openbook.event.controller.response.UserEventData;
 import com.openbook.openbook.event.controller.response.EventDetail;
 import com.openbook.openbook.event.controller.response.EventLayoutStatus;
+import com.openbook.openbook.event.service.common.CommonEventReviewService;
 import com.openbook.openbook.event.service.EventCommonService;
 import com.openbook.openbook.event.controller.request.EventRegistrationRequest;
 import com.openbook.openbook.event.service.EventLayoutCommonService;
@@ -30,6 +32,7 @@ public class UserEventController {
 
     private final EventCommonService eventCommonService;
     private final EventLayoutCommonService eventLayoutCommonService;
+    private final CommonEventReviewService eventReviewService;
 
     @PostMapping("/events")
     public ResponseEntity<ResponseMessage> registration(Authentication authentication,
@@ -64,6 +67,14 @@ public class UserEventController {
     public ResponseEntity<EventNoticeData> getEventNotice(@PathVariable Long notice_id) {
         return ResponseEntity.ok(eventCommonService.getEventNotice(notice_id));
     }
+
+
+    @PostMapping("/event/reviews")
+    public ResponseEntity<ResponseMessage> postReview(Authentication authentication, @Valid EventReviewRegisterRequest request) {
+        eventReviewService.registerEventReview(Long.valueOf(authentication.getName()), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("행사 리뷰 작성에 성공했습니다."));
+    }
+
 
     @GetMapping("events/search")
     public ResponseEntity<SliceResponse<UserEventData>> searchEvents(@RequestParam(value = "type", defaultValue = "eventName") String searchType,

--- a/src/main/java/com/openbook/openbook/event/controller/request/EventReviewRegisterRequest.java
+++ b/src/main/java/com/openbook/openbook/event/controller/request/EventReviewRegisterRequest.java
@@ -1,0 +1,14 @@
+package com.openbook.openbook.event.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record EventReviewRegisterRequest(
+        @NotNull long event_id,
+        @NotNull float star,
+        @NotBlank String content,
+        List<MultipartFile> images
+) {
+}

--- a/src/main/java/com/openbook/openbook/event/dto/EventReviewDto.java
+++ b/src/main/java/com/openbook/openbook/event/dto/EventReviewDto.java
@@ -1,0 +1,12 @@
+package com.openbook.openbook.event.dto;
+
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.user.entity.User;
+
+public record EventReviewDto(
+        User reviewer,
+        Event linkedEvent,
+        float star,
+        String content
+) {
+}

--- a/src/main/java/com/openbook/openbook/event/entity/EventReviewImage.java
+++ b/src/main/java/com/openbook/openbook/event/entity/EventReviewImage.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +27,7 @@ public class EventReviewImage {
 
     private String imageUrl;
 
-    @Size(min = 1, max = 5)
+    @Max(4)
     private int imageOrder;
 
     @Builder

--- a/src/main/java/com/openbook/openbook/event/repository/EventReviewImageRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventReviewImageRepository.java
@@ -1,0 +1,9 @@
+package com.openbook.openbook.event.repository;
+
+import com.openbook.openbook.event.entity.EventReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventReviewImageRepository extends JpaRepository<EventReviewImage, Long> {
+}

--- a/src/main/java/com/openbook/openbook/event/repository/EventReviewRepository.java
+++ b/src/main/java/com/openbook/openbook/event/repository/EventReviewRepository.java
@@ -1,0 +1,9 @@
+package com.openbook.openbook.event.repository;
+
+import com.openbook.openbook.event.entity.EventReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventReviewRepository extends JpaRepository<EventReview, Long> {
+}

--- a/src/main/java/com/openbook/openbook/event/service/common/CommonEventReviewService.java
+++ b/src/main/java/com/openbook/openbook/event/service/common/CommonEventReviewService.java
@@ -1,0 +1,49 @@
+package com.openbook.openbook.event.service.common;
+
+import com.openbook.openbook.event.controller.request.EventReviewRegisterRequest;
+import com.openbook.openbook.event.dto.EventReviewDto;
+import com.openbook.openbook.event.entity.Event;
+import com.openbook.openbook.event.entity.EventReview;
+import com.openbook.openbook.event.entity.dto.EventStatus;
+import com.openbook.openbook.event.service.core.EventReviewService;
+import com.openbook.openbook.event.service.core.EventService;
+import com.openbook.openbook.global.exception.ErrorCode;
+import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.core.UserService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommonEventReviewService {
+
+    private final UserService userService;
+    private final EventService eventService;
+    private final EventReviewService eventReviewService;
+
+    @Transactional
+    public void registerEventReview(Long loginUser, EventReviewRegisterRequest request) {
+        User user = userService.getUserOrException(loginUser);
+        Event event = eventService.getEventOrException(request.event_id());
+
+        if(!event.getStatus().equals(EventStatus.APPROVE)) {
+            throw new OpenBookException(ErrorCode.EVENT_NOT_APPROVED);
+        }
+        if(event.getOpenDate().isAfter(LocalDate.now())) {
+            throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
+        }
+
+        EventReviewDto dto = new EventReviewDto(user, event, request.star(), request.content());
+        EventReview review = eventReviewService.createEventReview(dto);
+        if(request.images() != null) {
+            for(int i=0;i<request.images().size();i++) {
+                eventReviewService.createEventReviewImage(review, request.images().get(i), i);
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/com/openbook/openbook/event/service/core/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventReviewService.java
@@ -1,0 +1,43 @@
+package com.openbook.openbook.event.service.core;
+
+import com.openbook.openbook.event.dto.EventReviewDto;
+import com.openbook.openbook.event.entity.EventReview;
+import com.openbook.openbook.event.entity.EventReviewImage;
+import com.openbook.openbook.event.repository.EventReviewImageRepository;
+import com.openbook.openbook.event.repository.EventReviewRepository;
+import com.openbook.openbook.global.util.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class EventReviewService {
+
+    private final EventReviewRepository eventReviewRepository;
+    private final EventReviewImageRepository eventReviewImageRepository;
+    private final S3Service s3Service;
+
+    public EventReview createEventReview(EventReviewDto dto){
+        return eventReviewRepository.save(
+                EventReview.builder()
+                        .reviewer(dto.reviewer())
+                        .linkedEvent(dto.linkedEvent())
+                        .star(dto.star())
+                        .content(dto.content())
+                        .build()
+        );
+
+    }
+
+    public void createEventReviewImage(EventReview linkedReview, MultipartFile image, int order){
+        eventReviewImageRepository.save(
+                EventReviewImage.builder()
+                        .linkedReview(linkedReview)
+                        .imageUrl(s3Service.uploadFileAndGetUrl(image))
+                        .imageOrder(order)
+                        .build()
+        );
+    }
+
+}

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     INACCESSIBLE_PERIOD(HttpStatus.CONFLICT, "접근 가능한 기간이 아닙니다."),
     UNDELETABLE_PERIOD(HttpStatus.CONFLICT, "삭제 가능한 기간이 아닙니다."),
+    CANNOT_REVIEW_PERIOD(HttpStatus.CONFLICT, "리뷰 작성 가능한 기간이 아닙니다."),
     ALREADY_RESERVED_AREA(HttpStatus.CONFLICT, "선택 가능한 구역이 아닙니다."),
     INVALID_DATE_RANGE(HttpStatus.CONFLICT, "입력된 날짜 범위가 유효하지 않습니다."),
     INVALID_LAYOUT_ENTRY(HttpStatus.CONFLICT, "입력된 배치도 형식에 오류가 있습니다."),

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     INVALID_LAYOUT_ENTRY(HttpStatus.CONFLICT, "입력된 배치도 형식에 오류가 있습니다."),
     EMPTY_TAG_DATA(HttpStatus.CONFLICT, "공백을 태그로 사용할 수 없습니다."),
     ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
+    EVENT_NOT_APPROVED(HttpStatus.CONFLICT, "승인되지 않은 행사입니다."),
     BOOTH_NOT_APPROVED(HttpStatus.CONFLICT, "승인되지 않은 부스입니다."),
     UNAVAILABLE_RESERVED_TIME(HttpStatus.CONFLICT, "예약 가능 시간이 아닙니다."),
     ALREADY_RESERVED_DATE(HttpStatus.CONFLICT, "이미 존재하는 예약 날짜 입니다."),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #184 

행사 리뷰를 등록하는 API를 개발하였습니다.

**API**
- POST
- /event/review

**요청 body** 
- event_id
- start
- content
- images (list)

**오류가 나는 상황**
- 승인 되지 않은 행사
- 아직 시작하지 않은 행사
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->

- **EventReviewRegisterRequest** 요청 객체 추가
- **ErrorCode** 오류 상황에 따른 에러 코드 추가
  - CANNOT_REVIEW_PERIOD
  - EVENT_NOT_APPROVED
- **EventReviewImage** imageOrder 에 저장되는 순서가 0부터 시작하도록 변경


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
요청
- POST {{local}}/event/review
- ![image](https://github.com/user-attachments/assets/5acd7ae8-96f8-42af-872f-4fd6d76b1c84)

결과 (성공)
- ![image](https://github.com/user-attachments/assets/5d8f5471-d380-4213-ab29-894e52012c96)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 이벤트 id를 이전처럼 경로에 넣지 않고 body 에 함께 넣었습니다!
개발 중에 참고하느라 카카오나 네이버 등의 api 문서들을 보는데, 중간 경로에 id를 안 넣고 body나 param으로 보내더라구요 확실히 아이디가 많아지면 중간에 넣기 애매할 수 있다는 생각이 들어서 따라해봤습니다! 
- 또 여러 문서들에서 복수 조회에만 s를 붙여 복수로 표현하고 단 건에 대해서는 그냥 단수를 사용하는 것을 깨달아서 하나의 행사에 하나의 리뷰를 작성한다는 의미로 그동안 s를 붙여 사용하던 방식과 다르게 단수로 엔드포인트를 작성했습니다! 
- 위에 작성한 내용 괜찮으시다면 이 후에도 이런 규칙을 사용해볼까 하는데, 혹시 다른 의견 등 생각나는 점 있으시면 편하게 말씀해주세요!!
- 일단 이미지를 제외한 별점, 내용은 필수여야 되도록 구현했습니다! 이 건에 대해선 회의 때 물어보도록 할게요!
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃