### PR TITLE
Fix: 일반 조회 api는 토큰 없이 호출할 수 있도록 설정

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -43,8 +43,8 @@ public class UserBoothController {
     }
 
     @GetMapping("/{boothId}")
-    public ResponseEntity<BoothDetail> getBooth(Authentication authentication, @PathVariable Long boothId){
-        return ResponseEntity.ok(boothCommonService.getBoothDetail(Long.valueOf(authentication.getName()), boothId));
+    public ResponseEntity<BoothDetail> getBooth(@PathVariable Long boothId){
+        return ResponseEntity.ok(boothCommonService.getBoothDetail(boothId));
     }
 
     @GetMapping("/{boothId}/notices")

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothDetail.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.booth.controller.response;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothTag;
 
+import com.openbook.openbook.user.dto.UserPublicData;
 import java.util.List;
 
 import static com.openbook.openbook.global.util.Formatter.getFormattingTime;
@@ -16,12 +17,12 @@ public record BoothDetail(
         String closeTime,
         List<BoothAreaData> location,
         List<String> tags,
+        UserPublicData boothManager,
         Long eventId,
-        String eventName,
-        boolean isUserManager
+        String eventName
 ) {
 
-    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreas, List<BoothTag> tags, boolean isUserManager){
+    public static BoothDetail of(Booth booth, List<BoothAreaData> boothAreas, List<BoothTag> tags){
         return new BoothDetail(
                 booth.getId(),
                 booth.getName(),
@@ -31,9 +32,9 @@ public record BoothDetail(
                 getFormattingTime(booth.getCloseTime()),
                 boothAreas,
                 tags.stream().map(BoothTag::getName).toList(),
+                UserPublicData.of(booth.getManager()),
                 booth.getLinkedEvent().getId(),
-                booth.getLinkedEvent().getName(),
-                isUserManager
+                booth.getLinkedEvent().getName()
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/BoothCommonService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/BoothCommonService.java
@@ -99,7 +99,7 @@ public class BoothCommonService {
     }
 
     @Transactional(readOnly = true)
-    public BoothDetail getBoothDetail(Long userId, Long boothId){
+    public BoothDetail getBoothDetail(Long boothId){
         Booth booth = boothService.getBoothOrException(boothId);
         if(!booth.getStatus().equals(BoothStatus.APPROVE)){
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
@@ -108,7 +108,7 @@ public class BoothCommonService {
                 .stream()
                 .map(BoothAreaData::of)
                 .collect(Collectors.toList());
-        return BoothDetail.of(booth, boothAreaData, boothTagService.getBoothTag(booth.getId()), Objects.equals(booth.getManager().getId(), userId));
+        return BoothDetail.of(booth, boothAreaData, boothTagService.getBoothTag(booth.getId()));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/openbook/openbook/configuration/SecurityConfig.java
+++ b/src/main/java/com/openbook/openbook/configuration/SecurityConfig.java
@@ -15,14 +15,32 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@RequiredArgsConstructor
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    private final String[] permitPaths = {
+            "/login",
+            "/signup",
+            "/booths/{boothId}",
+            "/booths/{boothId}/notices",
+            "/booths/notices/{noticeId}",
+            "/booths/search",
+            "/booths/{booth_id}/products",
+            "/booths/products/category",
+            "/booths/{booth_id}/reservations",
+            "/events",
+            "/events/{eventId}",
+            "/events/{event_id}/notices",
+            "/events/notices/{notice_id}",
+            "/event/reviews",
+            "/events/search"
+    };
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -41,10 +59,6 @@ public class SecurityConfig {
 
         return http.build();
     }
-    private final String[] permitPaths = {
-            "/login",
-            "/signup"
-    };
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {

--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -54,8 +54,8 @@ public class UserEventController {
     }
 
     @GetMapping("/events/{eventId}")
-    public ResponseEntity<EventDetail> getEvent(Authentication authentication, @PathVariable Long eventId) {
-        return ResponseEntity.ok(eventCommonService.getEventDetail(Long.valueOf(authentication.getName()), eventId));
+    public ResponseEntity<EventDetail> getEvent(@PathVariable Long eventId) {
+        return ResponseEntity.ok(eventCommonService.getEventDetail(eventId));
     }
 
     @GetMapping("/events/{event_id}/notices")

--- a/src/main/java/com/openbook/openbook/event/controller/response/EventDetail.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/EventDetail.java
@@ -19,7 +19,7 @@ public record EventDetail(
         String closeDate,
         List<String> tags,
         List<String> layoutImageUrls,
-        UserPublicData event_manager,
+        UserPublicData eventManager,
         int boothCount
 ) {
     public static EventDetail of(Event event, List<EventTag> tags, int boothCount) {

--- a/src/main/java/com/openbook/openbook/event/controller/response/EventDetail.java
+++ b/src/main/java/com/openbook/openbook/event/controller/response/EventDetail.java
@@ -5,6 +5,7 @@ import static com.openbook.openbook.global.util.JsonService.convertJsonToList;
 
 import com.openbook.openbook.event.entity.Event;
 import com.openbook.openbook.event.entity.EventTag;
+import com.openbook.openbook.user.dto.UserPublicData;
 import java.util.List;
 import java.util.Objects;
 
@@ -18,10 +19,10 @@ public record EventDetail(
         String closeDate,
         List<String> tags,
         List<String> layoutImageUrls,
-        int boothCount,
-        boolean isUserManager
+        UserPublicData event_manager,
+        int boothCount
 ) {
-    public static EventDetail of(Event event, Long userId, List<EventTag> tags, int boothCount) {
+    public static EventDetail of(Event event, List<EventTag> tags, int boothCount) {
         return new EventDetail(
                 event.getId(),
                 event.getName(),
@@ -32,8 +33,8 @@ public record EventDetail(
                 getFormattingDate(event.getCloseDate().atStartOfDay()),
                 tags.stream().map(EventTag::getName).toList(),
                 convertJsonToList(event.getLayout().getImageUrl()),
-                boothCount,
-                Objects.equals(event.getManager().getId(), userId)
+                UserPublicData.of(event.getManager()),
+                boothCount
         );
     }
 }

--- a/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
+++ b/src/main/java/com/openbook/openbook/event/service/EventCommonService.java
@@ -109,13 +109,13 @@ public class EventCommonService {
     }
 
     @Transactional(readOnly = true)
-    public EventDetail getEventDetail(final Long userId, final Long eventId) {
+    public EventDetail getEventDetail(final Long eventId) {
         Event event = eventService.getEventOrException(eventId);
         if(!event.getStatus().equals(EventStatus.APPROVE)) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         int boothCount = boothService.getBoothCountByEvent(event);
-        return EventDetail.of(event, userId, eventTagService.getEventTags(event.getId()), boothCount);
+        return EventDetail.of(event, eventTagService.getEventTags(event.getId()), boothCount);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #145 

기본 조회 api들을 토큰이 없어도 기본적으로 접근할 수 있도록 추가했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- SecurityConfig
permitPaths 에 접근 가능한 api 들을 추가했습니다.

- 행사 디테일 조회
- 부스 디테일 조회

기존 두 조회 api 에서 토큰에서 유저를 찾아 해당 행사, 부스의 매니저인지 반환하는 boolean 타입의 필드를 없애고 해당 행사, 부스의 매니저의 정보를 UserPublic 객체를 사용해 반환하도록 했습니다. 프론트에서 처리하도록 하면 될 것 같습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
모두 토큰 없이 호출했습니다.
- 행사 상세 조회
![image](https://github.com/user-attachments/assets/19f0e359-dfc4-4e42-9ee1-e63fe2e05674)

- 부스 상세 조회
![image](https://github.com/user-attachments/assets/470c7930-36a4-47a5-9aa6-86344c1f2f12)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 빠뜨린 부분, 토큰을 사용하지 않도록 변경해야 될 부분 등 발견하시면 말씀해주세요!
- 추가 궁금한 점, 개선할 점 등 편하게 의견 주세요!