### PR TITLE
Feat: 부스 관리자 시점 예약 정보 목록 조회

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/ManagerBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/ManagerBoothController.java
@@ -5,7 +5,6 @@ import com.openbook.openbook.booth.controller.request.ProductCategoryRegister;
 import com.openbook.openbook.booth.controller.request.ReserveRegistrationRequest;
 import com.openbook.openbook.booth.controller.request.ProductRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothManageData;
-import com.openbook.openbook.booth.controller.response.BoothReservationsResponse;
 import com.openbook.openbook.booth.controller.response.BoothReserveManageResponse;
 import com.openbook.openbook.booth.service.ManagerBoothService;
 import com.openbook.openbook.global.dto.ResponseMessage;

--- a/src/main/java/com/openbook/openbook/booth/controller/ManagerBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/ManagerBoothController.java
@@ -5,6 +5,8 @@ import com.openbook.openbook.booth.controller.request.ProductCategoryRegister;
 import com.openbook.openbook.booth.controller.request.ReserveRegistrationRequest;
 import com.openbook.openbook.booth.controller.request.ProductRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothManageData;
+import com.openbook.openbook.booth.controller.response.BoothReservationsResponse;
+import com.openbook.openbook.booth.controller.response.BoothReserveManageResponse;
 import com.openbook.openbook.booth.service.ManagerBoothService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
@@ -21,6 +23,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -63,6 +67,12 @@ public class ManagerBoothController {
                                                                @PathVariable Long boothId){
         managerBoothService.addReservation(Long.valueOf(authentication.getName()), request, boothId);
         return ResponseEntity.ok(new ResponseMessage("예약 추가에 성공했습니다."));
+    }
+
+    @GetMapping("manage/booths/{boothId}/reservations")
+    public ResponseEntity<List<BoothReserveManageResponse>> getManagedReservation(Authentication authentication,
+                                                                                  @PathVariable Long boothId){
+        return ResponseEntity.ok(managerBoothService.getAllManageReservations(Long.valueOf(authentication.getName()), boothId));
     }
 
     @PostMapping("/booths/{boothId}/notices")

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothReserveDetailManageResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothReserveDetailManageResponse.java
@@ -1,0 +1,25 @@
+package com.openbook.openbook.booth.controller.response;
+
+import com.openbook.openbook.booth.entity.BoothReservationDetail;
+import com.openbook.openbook.booth.entity.dto.BoothReservationStatus;
+import com.openbook.openbook.user.dto.UserPublicData;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+public record BoothReserveDetailManageResponse(
+        long id,
+        String times,
+        @Enumerated(EnumType.STRING)
+        BoothReservationStatus status,
+        UserPublicData reserveUser
+) {
+    public static BoothReserveDetailManageResponse of(BoothReservationDetail detail){
+        UserPublicData userPublicData = detail.getUser() != null ? UserPublicData.of(detail.getUser()) : null;
+        return new BoothReserveDetailManageResponse(
+                detail.getId(),
+                detail.getTime(),
+                detail.getStatus(),
+                userPublicData
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothReserveManageResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothReserveManageResponse.java
@@ -1,0 +1,28 @@
+package com.openbook.openbook.booth.controller.response;
+
+import static com.openbook.openbook.global.util.Formatter.getFormattingDate;
+import com.openbook.openbook.booth.entity.BoothReservation;
+
+import java.util.List;
+
+public record BoothReserveManageResponse(
+        long id,
+        String name,
+        String description,
+        String date,
+        List<BoothReserveDetailManageResponse> detailManageResponses,
+        int price,
+        String imageUrl
+) {
+    public static BoothReserveManageResponse of(BoothReservation reservation, List<BoothReserveDetailManageResponse> detailManage){
+        return new BoothReserveManageResponse(
+                reservation.getId(),
+                reservation.getName(),
+                reservation.getDescription(),
+                getFormattingDate(reservation.getDate().atStartOfDay()),
+                detailManage,
+                reservation.getPrice(),
+                reservation.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/booth/controller/response/BoothReserveManageResponse.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/response/BoothReserveManageResponse.java
@@ -14,7 +14,8 @@ public record BoothReserveManageResponse(
         int price,
         String imageUrl
 ) {
-    public static BoothReserveManageResponse of(BoothReservation reservation, List<BoothReserveDetailManageResponse> detailManage){
+    public static BoothReserveManageResponse of(BoothReservation reservation,
+                                                List<BoothReserveDetailManageResponse> detailManage){
         return new BoothReserveManageResponse(
                 reservation.getId(),
                 reservation.getName(),

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
@@ -34,8 +34,7 @@ public class BoothReservationDetail {
     }
 
     @Builder
-    public BoothReservationDetail(User user, BoothReservation boothReservation, String time){
-        this.user = user;
+    public BoothReservationDetail(BoothReservation boothReservation, String time){
         this.linkedReservation = boothReservation;
         this.time = time;
     }

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -5,6 +5,8 @@ import com.openbook.openbook.booth.controller.request.ProductCategoryRegister;
 import com.openbook.openbook.booth.controller.request.ReserveRegistrationRequest;
 import com.openbook.openbook.booth.controller.response.BoothAreaData;
 import com.openbook.openbook.booth.controller.response.BoothManageData;
+import com.openbook.openbook.booth.controller.response.BoothReserveDetailManageResponse;
+import com.openbook.openbook.booth.controller.response.BoothReserveManageResponse;
 import com.openbook.openbook.booth.dto.BoothNoticeDto;
 import com.openbook.openbook.booth.dto.BoothReservationDTO;
 import com.openbook.openbook.booth.entity.*;
@@ -30,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -112,6 +115,21 @@ public class ManagerBoothService {
                 new BoothReservationDTO(request.name(), request.description(), request.date(),
                         request.image(), request.price()), booth);
         boothReservationDetailService.createReservationDetail(request.times(), boothReservation);
+    }
+
+    @Transactional
+    public List<BoothReserveManageResponse> getAllManageReservations(Long userId, Long boothId){
+        Booth booth = getValidBoothOrException(userId, boothId);
+
+        List<BoothReservation> boothReservations = boothReservationService.getBoothReservations(booth.getId());
+        List<BoothReserveManageResponse> boothReserveManageResponses = new ArrayList<>();
+
+        for(BoothReservation reservation : boothReservations){
+            List<BoothReserveDetailManageResponse> detailManages = boothReservationDetailService.getReservationDetailsByReservation(reservation.getId())
+                    .stream().map(BoothReserveDetailManageResponse::of).toList();
+            boothReserveManageResponses.add(BoothReserveManageResponse.of(reservation, detailManages));
+        }
+        return boothReserveManageResponses;
     }
 
     @Transactional

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -124,7 +124,8 @@ public class ManagerBoothService {
         List<BoothReserveManageResponse> boothReserveManageResponses = new ArrayList<>();
 
         for(BoothReservation reservation : boothReservations){
-            List<BoothReserveDetailManageResponse> detailManages = boothReservationDetailService.getReservationDetailsByReservation(reservation.getId())
+            List<BoothReserveDetailManageResponse> detailManages =
+                    boothReservationDetailService.getReservationDetailsByReservation(reservation.getId())
                     .stream().map(BoothReserveDetailManageResponse::of).toList();
             boothReserveManageResponses.add(BoothReserveManageResponse.of(reservation, detailManages));
         }

--- a/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/ManagerBoothService.java
@@ -21,7 +21,6 @@ import com.openbook.openbook.booth.service.core.BoothService;
 import com.openbook.openbook.booth.service.core.BoothTagService;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
-import com.openbook.openbook.global.util.S3Service;
 import com.openbook.openbook.user.entity.User;
 import com.openbook.openbook.user.service.core.UserService;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #189 
GET manage/booths/{boothId}/reservations
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스 관리자가 응답 받는 데이터와 일반 유저가 받는 데이터 정보가 다르기 때문에 관리자용 response를 따로 만들었습니다. (BoothReserveManageResponse, BoothReserveDetailManageResponse)
- 예약자가 null 경우 조회했을 때 nullPointerException 에러가 나서 처리하기 위해 null 일 경우의 처리를 BoothReserveDetailManageResponse에서 따로 했습니다.
- 예약자 정보는 UserPublicData를 활용했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
<img width="825" alt="image" src="https://github.com/user-attachments/assets/0647c76e-8c6b-4827-a1f1-93c67205839e">
- 권한이 없을 경우
<img width="836" alt="image" src="https://github.com/user-attachments/assets/1f95ab87-52cc-4f6b-b4cc-147fb69e2dcc">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 관리자가 받아오는 데이터와 일반 유저가 받아오는 데이터가 다르기 때문에 response 를 더 늘리게 되었는데 점점 response가 무분별하게 늘어나는건 아닌지 하는 생각이 들었습니다 😭 타 프로젝트들을 참고해서 다른 방법을 찾아보려 했으나 잘 찾아지지 않아 우선 이 방법으로 구현했습니다. 혹시 의견 있으시면 말씀해주세요!
- response를 따로 만들게 되면서 관리자 response라는 점을 차별화 시키기 위해 기존 response 명에 manage 단어를 추가적으로 붙이게 되었습니다. 이외에도 기타 필드명도 manage 라는 단어가 붙게 되면서 클래스명이나 필드명이 좀 길어지게 되는 문제가 생겼는데 혹시 다른 좋은 네이밍 생각나신게 있으시다면 말씀해주세요! 😊
- 추가로 의견사항이나 질문 있으시면 리뷰 남겨주세요~