### PR TITLE
Feat: 행사 리뷰 삭제 API

### DIFF
--- a/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
+++ b/src/main/java/com/openbook/openbook/event/controller/UserEventController.java
@@ -21,6 +21,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -86,6 +87,12 @@ public class UserEventController {
     @GetMapping("/event/review/{review_id}")
     public ResponseEntity<EventReviewResponse> getReview(@PathVariable Long review_id) {
         return ResponseEntity.ok(eventReviewService.getEventReview(review_id));
+    }
+
+    @DeleteMapping("/event/reviews/{review_id}")
+    public ResponseEntity<ResponseMessage> deleteReview(Authentication authentication, @PathVariable Long review_id) {
+        eventReviewService.deleteReview(Long.parseLong(authentication.getName()), review_id);
+        return ResponseEntity.ok(new ResponseMessage("리뷰 삭제에 성공했습니다."));
     }
 
     @GetMapping("events/search")

--- a/src/main/java/com/openbook/openbook/event/service/common/CommonEventReviewService.java
+++ b/src/main/java/com/openbook/openbook/event/service/common/CommonEventReviewService.java
@@ -65,5 +65,9 @@ public class CommonEventReviewService {
         }
     }
 
+    @Transactional
+    public void deleteReview(long userId, long reviewId) {
+        eventReviewService.deleteEventReview(reviewId);
+    }
 
 }

--- a/src/main/java/com/openbook/openbook/event/service/common/CommonEventReviewService.java
+++ b/src/main/java/com/openbook/openbook/event/service/common/CommonEventReviewService.java
@@ -67,6 +67,10 @@ public class CommonEventReviewService {
 
     @Transactional
     public void deleteReview(long userId, long reviewId) {
+        EventReview review = eventReviewService.getEventReviewOrException(reviewId);
+        if(review.getReviewer().getId()!=userId) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
         eventReviewService.deleteEventReview(reviewId);
     }
 

--- a/src/main/java/com/openbook/openbook/event/service/core/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/event/service/core/EventReviewService.java
@@ -60,4 +60,8 @@ public class EventReviewService {
         return eventReviewImageRepository.findAllByLinkedReviewId(linkedReview.getId());
     }
 
+    public void deleteEventReview(long eventReviewId) {
+        eventReviewRepository.deleteById(eventReviewId);
+    }
+
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #195 

행사 리뷰를 삭제하는 API 를 개발했습니다.
- DELETE /event/reviews/{review_id}
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 삭제 서비스 및  컨트롤러 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
요청
- DELETE {{local}}/event/reviews/2 

결과
- ![image](https://github.com/user-attachments/assets/1e1e8aa2-5ec2-41ee-9faf-091d588e22d2)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃