### PR TITLE
Feat: 부스 예약 신청 API

### DIFF
--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -82,7 +82,7 @@ public class UserBoothController {
         return ResponseEntity.ok(commonProductService.findCategoryProducts(category_id, pageable));
     }
 
-    @PutMapping("/reserve/{detail_id}")
+    @PatchMapping("/reserve/{detail_id}")
     public ResponseEntity<ResponseMessage> reservation(Authentication authentication, @PathVariable Long detail_id){
         commonReservationService.reserveBooth(Long.valueOf(authentication.getName()), detail_id);
         return ResponseEntity.ok(new ResponseMessage("예약 신청이 되었습니다."));

--- a/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
+++ b/src/main/java/com/openbook/openbook/booth/controller/UserBoothController.java
@@ -5,7 +5,6 @@ import com.openbook.openbook.booth.controller.response.*;
 import com.openbook.openbook.booth.service.BoothCommonService;
 import com.openbook.openbook.booth.service.common.CommonProductService;
 import com.openbook.openbook.booth.service.common.CommonReservationService;
-import com.openbook.openbook.booth.service.core.BoothReservationService;
 import com.openbook.openbook.global.dto.ResponseMessage;
 import com.openbook.openbook.global.dto.SliceResponse;
 import jakarta.validation.Valid;
@@ -81,6 +80,12 @@ public class UserBoothController {
     public ResponseEntity<CategoryProductsResponse> getProductsByCategory(@RequestParam Long category_id,
                                                                           @PageableDefault(size = 5) Pageable pageable) {
         return ResponseEntity.ok(commonProductService.findCategoryProducts(category_id, pageable));
+    }
+
+    @PutMapping("/reserve/{detail_id}")
+    public ResponseEntity<ResponseMessage> reservation(Authentication authentication, @PathVariable Long detail_id){
+        commonReservationService.reserveBooth(Long.valueOf(authentication.getName()), detail_id);
+        return ResponseEntity.ok(new ResponseMessage("예약 신청이 되었습니다."));
     }
 
     @GetMapping("/{booth_id}/reservations")

--- a/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
+++ b/src/main/java/com/openbook/openbook/booth/entity/BoothReservationDetail.java
@@ -38,4 +38,9 @@ public class BoothReservationDetail {
         this.linkedReservation = boothReservation;
         this.time = time;
     }
+
+    public void updateUser(BoothReservationStatus status, User user) {
+        this.status = status;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
@@ -17,6 +17,7 @@ import com.openbook.openbook.user.service.core.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,8 +53,12 @@ public class CommonReservationService {
     }
 
     private void getReservationDetail(BoothReservationDetail boothReservationDetail){
-        if(!boothReservationDetail.getStatus().equals(BoothReservationStatus.EMPTY)){
+        if(!boothReservationDetail.getStatus().equals(BoothReservationStatus.EMPTY)) {
             throw new OpenBookException(ErrorCode.ALREADY_RESERVED_SERVICE);
+        }
+
+        if(LocalTime.parse(boothReservationDetail.getTime()).isBefore(LocalTime.now())){
+            throw new OpenBookException(ErrorCode.UNAVAILABLE_RESERVED_TIME);
         }
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
@@ -10,6 +10,8 @@ import com.openbook.openbook.booth.service.core.BoothReservationService;
 import com.openbook.openbook.booth.service.core.BoothService;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.core.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +24,7 @@ public class CommonReservationService {
     private final BoothService boothService;
     private final BoothReservationService boothReservationService;
     private final BoothReservationDetailService boothReservationDetailService;
+    private final UserService userService;
 
     public List<BoothReservationsResponse> getAllBoothReservations(long boothId){
         Booth booth = boothService.getBoothOrException(boothId);
@@ -37,5 +40,10 @@ public class CommonReservationService {
         }
 
         return boothReservationsResponses;
+    }
+
+    public void reserveBooth(Long userId, Long detailId){
+        User user = userService.getUserOrException(userId);
+        boothReservationDetailService.setUserToReservation(user, detailId);
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
@@ -48,11 +48,11 @@ public class CommonReservationService {
     public void reserveBooth(Long userId, Long detailId){
         User user = userService.getUserOrException(userId);
         BoothReservationDetail boothReservationDetail = boothReservationDetailService.getBoothReservationDetailOrException(detailId);
-        getReservationDetail(boothReservationDetail);
+        checkValidReservationDetail(boothReservationDetail);
         boothReservationDetailService.setUserToReservation(user, boothReservationDetail);
     }
 
-    private void getReservationDetail(BoothReservationDetail boothReservationDetail){
+    private void checkValidReservationDetail(BoothReservationDetail boothReservationDetail){
         if(!boothReservationDetail.getStatus().equals(BoothReservationStatus.EMPTY)) {
             throw new OpenBookException(ErrorCode.ALREADY_RESERVED_SERVICE);
         }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
@@ -4,6 +4,8 @@ import com.openbook.openbook.booth.controller.response.BoothReservationDetailRes
 import com.openbook.openbook.booth.controller.response.BoothReservationsResponse;
 import com.openbook.openbook.booth.entity.Booth;
 import com.openbook.openbook.booth.entity.BoothReservation;
+import com.openbook.openbook.booth.entity.BoothReservationDetail;
+import com.openbook.openbook.booth.entity.dto.BoothReservationStatus;
 import com.openbook.openbook.booth.entity.dto.BoothStatus;
 import com.openbook.openbook.booth.service.core.BoothReservationDetailService;
 import com.openbook.openbook.booth.service.core.BoothReservationService;
@@ -43,6 +45,15 @@ public class CommonReservationService {
     }
 
     public void reserveBooth(Long userId, Long detailId){
-        boothReservationDetailService.setUserToReservation(userId, detailId);
+        User user = userService.getUserOrException(userId);
+        BoothReservationDetail boothReservationDetail = boothReservationDetailService.getBoothReservationDetailOrException(detailId);
+        getReservationDetail(boothReservationDetail);
+        boothReservationDetailService.setUserToReservation(user, boothReservationDetail);
+    }
+
+    private void getReservationDetail(BoothReservationDetail boothReservationDetail){
+        if(!boothReservationDetail.getStatus().equals(BoothReservationStatus.EMPTY)){
+            throw new OpenBookException(ErrorCode.ALREADY_RESERVED_SERVICE);
+        }
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/common/CommonReservationService.java
@@ -43,7 +43,6 @@ public class CommonReservationService {
     }
 
     public void reserveBooth(Long userId, Long detailId){
-        User user = userService.getUserOrException(userId);
-        boothReservationDetailService.setUserToReservation(user, detailId);
+        boothReservationDetailService.setUserToReservation(userId, detailId);
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationDetailService.java
@@ -2,9 +2,14 @@ package com.openbook.openbook.booth.service.core;
 
 import com.openbook.openbook.booth.entity.BoothReservation;
 import com.openbook.openbook.booth.entity.BoothReservationDetail;
+import com.openbook.openbook.booth.entity.dto.BoothReservationStatus;
 import com.openbook.openbook.booth.repository.BoothReservationDetailRepository;
+import com.openbook.openbook.global.exception.ErrorCode;
+import com.openbook.openbook.global.exception.OpenBookException;
+import com.openbook.openbook.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,6 +17,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoothReservationDetailService {
     private final BoothReservationDetailRepository boothReservationDetailRepository;
+
+    public BoothReservationDetail getBoothReservationDetailOrException(final Long id) {
+        return boothReservationDetailRepository.findById(id).orElseThrow(() ->
+                new OpenBookException(ErrorCode.RESERVATION_NOT_FOUND)
+        );
+    }
     public void createReservationDetail(List<String> reservationDetails, BoothReservation boothReservation){
         for(String time : reservationDetails){
             boothReservationDetailRepository.save(
@@ -25,5 +36,19 @@ public class BoothReservationDetailService {
 
     public List<BoothReservationDetail> getReservationDetailsByReservation(Long reservationId){
         return boothReservationDetailRepository.findBoothReservationDetailsByLinkedReservationId(reservationId);
+    }
+
+    @Transactional
+    public void setUserToReservation(User user, Long reserveId){
+        BoothReservationDetail boothReservationDetail = getReservationDetail(reserveId);
+        boothReservationDetail.updateUser(BoothReservationStatus.WAITING, user);
+    }
+
+    private BoothReservationDetail getReservationDetail(Long reserveId){
+        BoothReservationDetail boothReservationDetail = getBoothReservationDetailOrException(reserveId);
+        if(!boothReservationDetail.getStatus().equals(BoothReservationStatus.EMPTY)){
+            throw new OpenBookException(ErrorCode.ALREADY_RESERVED_SERVICE);
+        }
+        return boothReservationDetail;
     }
 }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationDetailService.java
@@ -7,6 +7,7 @@ import com.openbook.openbook.booth.repository.BoothReservationDetailRepository;
 import com.openbook.openbook.global.exception.ErrorCode;
 import com.openbook.openbook.global.exception.OpenBookException;
 import com.openbook.openbook.user.entity.User;
+import com.openbook.openbook.user.service.core.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoothReservationDetailService {
     private final BoothReservationDetailRepository boothReservationDetailRepository;
+    private final UserService userService;
 
     public BoothReservationDetail getBoothReservationDetailOrException(final Long id) {
         return boothReservationDetailRepository.findById(id).orElseThrow(() ->
@@ -39,7 +41,8 @@ public class BoothReservationDetailService {
     }
 
     @Transactional
-    public void setUserToReservation(User user, Long reserveId){
+    public void setUserToReservation(Long userId, Long reserveId){
+        User user = userService.getUserOrException(userId);
         BoothReservationDetail boothReservationDetail = getReservationDetail(reserveId);
         boothReservationDetail.updateUser(BoothReservationStatus.WAITING, user);
     }

--- a/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/booth/service/core/BoothReservationDetailService.java
@@ -18,7 +18,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoothReservationDetailService {
     private final BoothReservationDetailRepository boothReservationDetailRepository;
-    private final UserService userService;
 
     public BoothReservationDetail getBoothReservationDetailOrException(final Long id) {
         return boothReservationDetailRepository.findById(id).orElseThrow(() ->
@@ -41,17 +40,9 @@ public class BoothReservationDetailService {
     }
 
     @Transactional
-    public void setUserToReservation(Long userId, Long reserveId){
-        User user = userService.getUserOrException(userId);
-        BoothReservationDetail boothReservationDetail = getReservationDetail(reserveId);
+    public void setUserToReservation(User user, BoothReservationDetail boothReservationDetail){
         boothReservationDetail.updateUser(BoothReservationStatus.WAITING, user);
     }
 
-    private BoothReservationDetail getReservationDetail(Long reserveId){
-        BoothReservationDetail boothReservationDetail = getBoothReservationDetailOrException(reserveId);
-        if(!boothReservationDetail.getStatus().equals(BoothReservationStatus.EMPTY)){
-            throw new OpenBookException(ErrorCode.ALREADY_RESERVED_SERVICE);
-        }
-        return boothReservationDetail;
-    }
+
 }

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
     UNAVAILABLE_RESERVED_TIME(HttpStatus.CONFLICT, "예약 가능 시간이 아닙니다."),
     ALREADY_RESERVED_DATE(HttpStatus.CONFLICT, "이미 존재하는 예약 날짜 입니다."),
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
-    ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 날짜(또는 시간) 입니다."),
+    ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 시간 입니다."),
 
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
     UNAVAILABLE_RESERVED_TIME(HttpStatus.CONFLICT, "예약 가능 시간이 아닙니다."),
     ALREADY_RESERVED_DATE(HttpStatus.CONFLICT, "이미 존재하는 예약 날짜 입니다."),
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
-    ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "예약 가능한 시간이 아닙니다."),
+    ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 날짜(또는 시간) 입니다."),
 
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),

--- a/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     UNAVAILABLE_RESERVED_TIME(HttpStatus.CONFLICT, "예약 가능 시간이 아닙니다."),
     ALREADY_RESERVED_DATE(HttpStatus.CONFLICT, "이미 존재하는 예약 날짜 입니다."),
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
+    ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "예약 가능한 시간이 아닙니다."),
 
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),
@@ -47,6 +48,7 @@ public enum ErrorCode {
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰 정보를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약 정보를 찾을 수 없습니다."),
 
     // INTERNET SERVER ERROR
     FIlE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.")


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #194 
PUT booths/reserve/{detail_id}
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothReservationDetailService에서 setUserToReservation메서드를 만들어서 예약 상세 객체를 불러와서 상태를 수정하는 작업을 했습니다.
- getReservationDetail를 통해 찾으려는 부스 상세 객체의 예약 상태와 존재 여부를 판단하고 조회할 수 있게 했습니다.
- ErrorCode에 ALREADY_RESERVED_SERVICE라는 에러 메세지를 추가했습니다. 이는 이미 예약된 서비스에 사용자가 예약하려고 하는 경우에 반환됩니다.
- BoothReservationDetail 엔티티에 updateUser라는 메서드를 만들어서 user와 status 정보를 update 할 수 있게 구현했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
![image](https://github.com/user-attachments/assets/d522a7e1-337d-41af-af18-a385085675ae)
![image](https://github.com/user-attachments/assets/8182a4e2-192e-49dd-a832-c4308b7aa368)
- 이미 예약된 서비스를 예약하고자 할 경우
![image](https://github.com/user-attachments/assets/9312ebae-fc17-4abd-be31-09d803934dc5)
- 존재하지 않는 예약일 경우
![image](https://github.com/user-attachments/assets/e68032f1-2155-4a1f-b50c-10b57488d56f)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금한 점이나 의견 있으시면 리뷰 부탁드립니다!