### PR TITLE
Refactor: 부스 상세 정보에 운영 날짜 추가

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/api/booth/response/BoothDetail.java
@@ -5,6 +5,8 @@ import com.openbook.openbook.service.booth.dto.BoothDto;
 import com.openbook.openbook.service.booth.dto.BoothTagDto;
 import com.openbook.openbook.api.event.response.EventPublicResponse;
 import com.openbook.openbook.api.user.response.UserPublicResponse;
+
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.openbook.openbook.util.Formatter.getFormattingTime;
@@ -16,6 +18,8 @@ public record BoothDetail(
         String mainImageUrl,
         String openTime,
         String closeTime,
+        LocalDate openDate,
+        LocalDate closeDate,
         List<BoothAreaDto> location,
         List<String> tags,
         UserPublicResponse manager,
@@ -29,6 +33,8 @@ public record BoothDetail(
                 booth.mainImageUrl(),
                 getFormattingTime(booth.openTime()),
                 getFormattingTime(booth.closeTime()),
+                booth.linkedEvent().openDate(),
+                booth.linkedEvent().closeDate(),
                 booth.locations(),
                 booth.tags().stream().map(BoothTagDto::name).toList(),
                 UserPublicResponse.of(booth.manager()),

--- a/src/main/java/com/openbook/openbook/api/booth/response/BoothDetail.java
+++ b/src/main/java/com/openbook/openbook/api/booth/response/BoothDetail.java
@@ -7,6 +7,7 @@ import com.openbook.openbook.api.event.response.EventPublicResponse;
 import com.openbook.openbook.api.user.response.UserPublicResponse;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.openbook.openbook.util.Formatter.getFormattingTime;
@@ -16,10 +17,8 @@ public record BoothDetail(
         String name,
         String description,
         String mainImageUrl,
-        String openTime,
-        String closeTime,
-        LocalDate openDate,
-        LocalDate closeDate,
+        LocalDateTime openData,
+        LocalDateTime closeData,
         List<BoothAreaDto> location,
         List<String> tags,
         UserPublicResponse manager,
@@ -31,10 +30,8 @@ public record BoothDetail(
                 booth.name(),
                 booth.description(),
                 booth.mainImageUrl(),
-                getFormattingTime(booth.openTime()),
-                getFormattingTime(booth.closeTime()),
-                booth.linkedEvent().openDate(),
-                booth.linkedEvent().closeDate(),
+                booth.openTime(),
+                booth.closeTime(),
                 booth.locations(),
                 booth.tags().stream().map(BoothTagDto::name).toList(),
                 UserPublicResponse.of(booth.manager()),


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #213

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스 상세 조회를 할 때 해당 부스의 운영 날짜 (opendate, closedate)를 추가 응답하도록 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
![image](https://github.com/user-attachments/assets/3678279c-0135-47e3-a9d3-6df72fa954dd)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 응답 할 때 운영 날짜를 EventPublicResponse에 추가해서 해볼까하다가 일단 따로 빼두긴 했는데 어떤 쪽이 나을지 의견 주시면 감사하겠습니다!
- 추가 의견이나 질문사항 있으시면 리뷰 남겨주세요!