### PR TITLE
Feat: 북마크 생성 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -1,0 +1,11 @@
+package com.openbook.openbook.api.user;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BookmarkController {
+
+}

--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -1,11 +1,28 @@
 package com.openbook.openbook.api.user;
 
 
+import com.openbook.openbook.api.ResponseMessage;
+import com.openbook.openbook.api.user.request.BookmarkRequest;
+import com.openbook.openbook.service.user.BookmarkService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/bookmark")
+    public ResponseMessage bookmark(Authentication authentication, @Valid BookmarkRequest request) {
+        bookmarkService.createBookmark(Long.parseLong(authentication.getName()), request);
+        return new ResponseMessage("북마크에 성공했습니다.");
+    }
 
 }

--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +21,8 @@ public class BookmarkController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/bookmark")
-    public ResponseMessage bookmark(Authentication authentication, @Valid BookmarkRequest request) {
+    public ResponseMessage bookmark(Authentication authentication,
+                                    @Valid @RequestBody BookmarkRequest request) {
         bookmarkService.createBookmark(Long.parseLong(authentication.getName()), request);
         return new ResponseMessage("북마크에 성공했습니다.");
     }

--- a/src/main/java/com/openbook/openbook/api/user/request/BookmarkRequest.java
+++ b/src/main/java/com/openbook/openbook/api/user/request/BookmarkRequest.java
@@ -1,10 +1,9 @@
 package com.openbook.openbook.api.user.request;
 
-import com.openbook.openbook.domain.user.dto.BookmarkType;
 import jakarta.validation.constraints.NotNull;
 
 public record BookmarkRequest(
-        @NotNull BookmarkType type,
+        @NotNull String type,
         @NotNull long resourceId,
         Boolean alarmSet
 ) {

--- a/src/main/java/com/openbook/openbook/api/user/request/BookmarkRequest.java
+++ b/src/main/java/com/openbook/openbook/api/user/request/BookmarkRequest.java
@@ -1,0 +1,11 @@
+package com.openbook.openbook.api.user.request;
+
+import com.openbook.openbook.domain.user.dto.BookmarkType;
+import jakarta.validation.constraints.NotNull;
+
+public record BookmarkRequest(
+        @NotNull BookmarkType type,
+        @NotNull long resourceId,
+        Boolean alarmSet
+) {
+}

--- a/src/main/java/com/openbook/openbook/domain/user/dto/BookmarkType.java
+++ b/src/main/java/com/openbook/openbook/domain/user/dto/BookmarkType.java
@@ -1,6 +1,16 @@
 package com.openbook.openbook.domain.user.dto;
 
+import com.openbook.openbook.exception.ErrorCode;
+import com.openbook.openbook.exception.OpenBookException;
+
 public enum BookmarkType {
     EVENT,
-    BOOTH
+    BOOTH;
+    public static BookmarkType fromString(String request) {
+        return switch (request) {
+            case "EVENT" -> EVENT;
+            case "BOOTH" -> BOOTH;
+            default -> throw new OpenBookException(ErrorCode.INVALID_BOOKMARK_TYPE);
+        };
+    }
 }

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     ALREADY_RESERVED_DATE(HttpStatus.CONFLICT, "이미 존재하는 예약 날짜 입니다."),
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
     ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 시간 입니다."),
+    ALREADY_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크 목록에 존재합니다."),
 
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 
     // BAD REQUEST
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않습니다."),
+    INVALID_BOOKMARK_TYPE(HttpStatus.BAD_REQUEST, "북마크 타입이 유효하지 않습니다."),
 
     // CONFLICT
     ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),

--- a/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.openbook.openbook.repository.user;
+
+import com.openbook.openbook.domain.user.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
@@ -1,9 +1,13 @@
 package com.openbook.openbook.repository.user;
 
 import com.openbook.openbook.domain.user.Bookmark;
+import com.openbook.openbook.domain.user.dto.BookmarkType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    boolean existsByUserIdAndResourceIdAndBookmarkType(long userId, long resourceId, BookmarkType type);
+
 }

--- a/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
+++ b/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
@@ -1,0 +1,10 @@
+package com.openbook.openbook.service.user;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+}

--- a/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
+++ b/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
@@ -4,6 +4,7 @@ package com.openbook.openbook.service.user;
 import com.openbook.openbook.api.user.request.BookmarkRequest;
 import com.openbook.openbook.domain.user.Bookmark;
 import com.openbook.openbook.domain.user.User;
+import com.openbook.openbook.domain.user.dto.BookmarkType;
 import com.openbook.openbook.repository.user.BookmarkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +22,7 @@ public class BookmarkService {
         User user = userService.getUserOrException(userId);
         bookmarkRepository.save( Bookmark.builder()
                 .user(user)
-                .bookmarkType(request.type())
+                .bookmarkType(BookmarkType.fromString(request.type()))
                 .resourceId(request.resourceId())
                 .alarmSet(request.alarmSet() == null || request.alarmSet())
                 .build()

--- a/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
+++ b/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
@@ -1,10 +1,31 @@
 package com.openbook.openbook.service.user;
 
 
+import com.openbook.openbook.api.user.request.BookmarkRequest;
+import com.openbook.openbook.domain.user.Bookmark;
+import com.openbook.openbook.domain.user.User;
+import com.openbook.openbook.repository.user.BookmarkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
+
+    private final UserService userService;
+    private final BookmarkRepository bookmarkRepository;
+
+    @Transactional
+    public void createBookmark(long userId, BookmarkRequest request) {
+        User user = userService.getUserOrException(userId);
+        bookmarkRepository.save( Bookmark.builder()
+                .user(user)
+                .bookmarkType(request.type())
+                .resourceId(request.resourceId())
+                .alarmSet(request.alarmSet() == null || request.alarmSet())
+                .build()
+        );
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
+++ b/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
@@ -5,7 +5,10 @@ import com.openbook.openbook.api.user.request.BookmarkRequest;
 import com.openbook.openbook.domain.user.Bookmark;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.domain.user.dto.BookmarkType;
+import com.openbook.openbook.exception.ErrorCode;
+import com.openbook.openbook.exception.OpenBookException;
 import com.openbook.openbook.repository.user.BookmarkRepository;
+import java.awt.print.Book;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,14 +18,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookmarkService {
 
     private final UserService userService;
+
     private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public void createBookmark(long userId, BookmarkRequest request) {
         User user = userService.getUserOrException(userId);
+        BookmarkType type = BookmarkType.fromString(request.type());
+        if(bookmarkRepository.existsByUserIdAndResourceIdAndBookmarkType(userId, request.resourceId(), type)) {
+            throw new OpenBookException(ErrorCode.ALREADY_BOOKMARK);
+        }
         bookmarkRepository.save( Bookmark.builder()
                 .user(user)
-                .bookmarkType(BookmarkType.fromString(request.type()))
+                .bookmarkType(type)
                 .resourceId(request.resourceId())
                 .alarmSet(request.alarmSet() == null || request.alarmSet())
                 .build()


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #207 

북마크를 생성하는 API 를 개발했습니다.

**API**
- POST
- /bookmark

**RequestBody**
- type
- resoureId
- alarmSet

**Response**
- message
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BookmarkRequest 객체 추가
- Bookmark 계층별 클래스 추가
- ErrorCode: 예외 상황에 따른 에러 코드 추가
  - INVALID_BOOKMARK_TYPE
  - ALREADY_BOOKMARK


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**1. 성공** 
```
POST /bookmark
{
    "type":"EVENT",
    "resourceId":60,
    "alarmSet":false

}
```
![image](https://github.com/user-attachments/assets/0a2ec2fd-cde6-42a1-8ac2-489fe26f9769)

**2. 실패 : 유효하지 않는 북마크 타입**
```
POST /bookmark
{
    "type":"X",
    "resourceId":60,
    "alarmSet":false

}
```
![image](https://github.com/user-attachments/assets/2563e96d-9003-4b86-826a-437283a06049)

**3. 실패 : 이미 북마크 한 경우**
```
POST /bookmark
{
    "type":"EVENT",
    "resourceId":60,
    "alarmSet":false

}
```
![image](https://github.com/user-attachments/assets/9957b83f-62aa-49e5-be3e-f2c4b4109fbd)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 요청으로 받는 String 형의 type을 Enum 으로 변환하는 과정을 Enum 클래스 안에서 진행하도록 구현했습니다.
그동안은 해당 과정을 Service 클래스에서 하도록 구현했었는데, 이 방식으로 하니 코드 가독성이나 재사용성 부분에서 훨씬 나은 것 같다고 느껴졌습니다. 그래서 괜찮으시면 그동안 Service에 작성했던 과정들을 Enum 클래스에서 이뤄지도록 리팩터링 할까 하는데, 어떻게 생각하시는지 의견을 듣고 싶습니다!
- alarmSet 의 경우 필수 값은 아니도록 했으며 null 인 경우 true 를 반환하도록 했습니다. 
해당 건은 다음 회의 때 말해보겠습니다! 
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃