### PR TITLE
Fix: 부스 도메인의 조회 api 오류

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothController.java
@@ -30,12 +30,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/booths")
 public class BoothController {
 
     private final BoothService boothService;
 
-    @PostMapping
+    @PostMapping("/booths")
     public ResponseEntity<ResponseMessage> registration(Authentication authentication, @Valid BoothRegistrationRequest request){
         boothService.boothRegistration(Long.valueOf(authentication.getName()), request);
         return ResponseEntity
@@ -44,18 +43,18 @@ public class BoothController {
 
     }
 
-    @GetMapping
+    @GetMapping("/booths")
     public ResponseEntity<SliceResponse<BoothBasicData>> getBooths(@PageableDefault(size = 6) Pageable pageable){
         return ResponseEntity.ok(SliceResponse.of(boothService.getBooths(pageable).map(BoothBasicData::of)));
     }
 
-    @GetMapping("/{boothId}")
+    @GetMapping("/booths/{boothId}")
     public ResponseEntity<BoothDetail> getBooth(@PathVariable Long boothId){
         return ResponseEntity.ok(BoothDetail.of(boothService.getBoothById(boothId)));
     }
 
 
-    @GetMapping("/search")
+    @GetMapping("/booths/search")
     public ResponseEntity<SliceResponse<BoothBasicData>> searchBoothName(@RequestParam(value = "type") String searchType,
                                                                          @RequestParam(value = "query", defaultValue = "") String query,
                                                                          @RequestParam(value = "page", defaultValue = "0") int page,

--- a/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
@@ -32,12 +32,12 @@ public class BoothNoticeController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
     }
 
-    @GetMapping("/{boothId}/notices")
+    @GetMapping("/booths/{boothId}/notices")
     public SliceResponse<BoothNoticeResponse> getBoothNotices(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
         return SliceResponse.of(boothNoticeService.getBoothNotices(boothId, pageable).map(BoothNoticeResponse::of));
     }
 
-    @GetMapping("/notices/{noticeId}")
+    @GetMapping("/booths/notices/{noticeId}")
     public ResponseEntity<BoothNoticeResponse> getBoothNotice(@PathVariable Long noticeId){
         return ResponseEntity.ok(BoothNoticeResponse.of(boothNoticeService.getBoothNotice(noticeId)));
     }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
@@ -42,18 +42,18 @@ public class BoothProductController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("상품 추가에 성공했습니다."));
     }
 
-    @GetMapping("/{booth_id}/product-category")
+    @GetMapping("/booths/{booth_id}/product-category")
     public ResponseEntity<List<ProductCategoryResponse>> getProductCategory(@PathVariable Long booth_id) {
         return ResponseEntity.ok(boothProductService.getProductCategoryResponseList(booth_id));
     }
 
-    @GetMapping("/{booth_id}/products")
+    @GetMapping("/booths/{booth_id}/products")
     public ResponseEntity<List<CategoryProductsResponse>> getAllBoothProducts(@PathVariable Long booth_id,
                                                                               @PageableDefault(size = 5) Pageable pageable) {
         return ResponseEntity.ok(boothProductService.findAllBoothProducts(booth_id, pageable));
     }
 
-    @GetMapping("/products/category")
+    @GetMapping("/booths/products/category")
     public ResponseEntity<CategoryProductsResponse> getProductsByCategory(@RequestParam Long category_id,
                                                                           @PageableDefault(size = 5) Pageable pageable) {
         return ResponseEntity.ok(boothProductService.findCategoryProducts(category_id, pageable));

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
@@ -37,13 +37,13 @@ public class BoothReservationController {
                 .stream().map(BoothReserveManageResponse::of).toList();
     }
 
-    @PatchMapping("/reserve/{detail_id}")
+    @PatchMapping("/booths/reserve/{detail_id}")
     public ResponseEntity<ResponseMessage> reservation(Authentication authentication, @PathVariable Long detail_id){
         reservationService.reserveBooth(Long.valueOf(authentication.getName()), detail_id);
         return ResponseEntity.ok(new ResponseMessage("예약 신청이 되었습니다."));
     }
 
-    @GetMapping("/{booth_id}/reservations")
+    @GetMapping("/booths/{booth_id}/reservations")
     public List<BoothReserveResponse> getAllBoothReservations(@PathVariable Long booth_id){
         return reservationService.getReservationsByBooth(booth_id).stream().map(BoothReserveResponse::of).toList();
     }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
@@ -19,7 +19,7 @@ public class BoothReviewController {
     private final BoothReviewService boothReviewService;
 
 
-    @PostMapping("/review")
+    @PostMapping("/booths/review")
     public ResponseEntity<ResponseMessage> postReview(Authentication authentication,
                                                       @Valid BoothReviewRegisterRequest request){
         boothReviewService.registerBoothReview(Long.valueOf(authentication.getName()), request);

--- a/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
@@ -38,8 +38,9 @@ public class BoothNoticeService {
     }
 
     @Transactional(readOnly = true)
-    public BoothNoticeDto getBoothNotice(Long boothId){
-        return BoothNoticeDto.of(getBoothNoticeOrException(boothId), boothService.getBoothById(boothId));
+    public BoothNoticeDto getBoothNotice(Long noticeId){
+        BoothNotice notice = getBoothNoticeOrException(noticeId);
+        return BoothNoticeDto.of(notice, boothService.getBoothById(notice.getLinkedBooth().getId()));
     }
 
     @Transactional

--- a/src/main/java/com/openbook/openbook/service/booth/dto/BoothReservationDetailDto.java
+++ b/src/main/java/com/openbook/openbook/service/booth/dto/BoothReservationDetailDto.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.service.booth.dto;
 
+
 import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import com.openbook.openbook.domain.booth.dto.BoothReservationStatus;
 import com.openbook.openbook.service.user.dto.UserDto;
@@ -16,7 +17,7 @@ public record BoothReservationDetailDto(
                 detail.getId(),
                 detail.getTime(),
                 detail.getStatus(),
-                UserDto.of(detail.getUser())
+                detail.getUser() != null ? UserDto.of(detail.getUser()) : null
         );
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #216 


해결된 에러
- 부스 예약 조회 시, 예약자가 없는 경우의 에러
- 부스 공지 조회시의 에러
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 예약자 정보를 가져올 떄, null 인 경우 null 이 저장되도록 처리
- 부스 공지 서비스에서 notice id 를 사용하도록 로직 변경
- BoothNotice 등 api 경로 앞에 /booths 추가
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**1. 부스 공지 단 건 조회**
![image](https://github.com/user-attachments/assets/c9d61370-96c0-4e4c-a98b-48e8cc2a4f9a)

**2. 부스 예약 정보 조회**
![image](https://github.com/user-attachments/assets/cc0d4584-e4db-4139-b41e-e41cb7d2fa62)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 리팩터링 전에 api 들이 존재하던 클래스가 `@RequestMapping("/booths")` 가 붙어 있었는데
그대로 가져올 때 /booths 부분이 빠지게 되었습니다. 해당 부분도 추가했습니다. 😥
헷갈릴 수 있어 `@RequestMapping("/booths")` 은 일단 해제했습니다.