### PR TITLE
Feat: 부스 예약 상태 변경 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
@@ -43,7 +43,7 @@ public class BoothReservationController {
     public ResponseEntity<ResponseMessage> changeReserveStatus(Authentication authentication,
                                                                @RequestBody ReserveStatusUpdateRequest request,
                                                                @PathVariable Long detail_id){
-        reservationService.changeReserveStatus(detail_id, request.status(), Long.valueOf(authentication.getName()));
+        reservationService.changeReserveStatus(detail_id, request, Long.valueOf(authentication.getName()));
         return ResponseEntity.ok(new ResponseMessage("예약 상태가 변경되었습니다."));
     }
 

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.api.booth;
 
 import com.openbook.openbook.api.booth.request.ReserveRegistrationRequest;
+import com.openbook.openbook.api.booth.request.ReserveStatusUpdateRequest;
 import com.openbook.openbook.api.booth.response.BoothReserveResponse;
 import com.openbook.openbook.api.booth.response.BoothReserveManageResponse;
 import com.openbook.openbook.service.booth.BoothReservationService;
@@ -35,6 +36,14 @@ public class BoothReservationController {
                                                                   @PathVariable Long boothId){
         return reservationService.getAllManageReservations(Long.valueOf(authentication.getName()), boothId)
                 .stream().map(BoothReserveManageResponse::of).toList();
+    }
+
+    @PatchMapping("/manage/booths/reserve/{detail_id}")
+    public ResponseEntity<ResponseMessage> changeReserveStatus(Authentication authentication,
+                                                               @RequestBody ReserveStatusUpdateRequest request,
+                                                               @PathVariable Long detail_id){
+        reservationService.changeReserveStatus(detail_id, request.status(), Long.valueOf(authentication.getName()));
+        return ResponseEntity.ok(new ResponseMessage("예약 상태가 변경되었습니다."));
     }
 
     @PatchMapping("/booths/reserve/{detail_id}")

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/openbook/openbook/api/booth/request/ReserveStatusUpdateRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/ReserveStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.openbook.openbook.api.booth.request;
+
+import com.openbook.openbook.domain.booth.dto.BoothReservationStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ReserveStatusUpdateRequest(
+        @NotNull BoothReservationStatus status
+        ) {
+}

--- a/src/main/java/com/openbook/openbook/api/booth/request/ReserveStatusUpdateRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/ReserveStatusUpdateRequest.java
@@ -1,9 +1,8 @@
 package com.openbook.openbook.api.booth.request;
 
-import com.openbook.openbook.domain.booth.dto.BoothReservationStatus;
 import jakarta.validation.constraints.NotNull;
 
 public record ReserveStatusUpdateRequest(
-        @NotNull BoothReservationStatus status
+        @NotNull String status
         ) {
 }

--- a/src/main/java/com/openbook/openbook/domain/booth/dto/BoothReservationStatus.java
+++ b/src/main/java/com/openbook/openbook/domain/booth/dto/BoothReservationStatus.java
@@ -1,10 +1,21 @@
 package com.openbook.openbook.domain.booth.dto;
 
+import com.openbook.openbook.exception.ErrorCode;
+import com.openbook.openbook.exception.OpenBookException;
 import lombok.Getter;
 
 @Getter
 public enum BoothReservationStatus {
     EMPTY,
     WAITING,
-    COMPLETE
+    COMPLETE;
+
+    public static BoothReservationStatus fromString(String request){
+        return switch (request){
+            case "EMPTY" -> EMPTY;
+            case "WAITING" -> WAITING;
+            case "COMPLETE" -> COMPLETE;
+            default -> throw new OpenBookException(ErrorCode.INVALID_RESERVATION_TYPE);
+        };
+    }
 }

--- a/src/main/java/com/openbook/openbook/domain/user/dto/AlarmType.java
+++ b/src/main/java/com/openbook/openbook/domain/user/dto/AlarmType.java
@@ -14,7 +14,10 @@ public enum AlarmType {
     EVENT_REJECTED("행사 등록이 거부되었습니다."),
 
     BOOTH_APPROVED("부스 등록이 승인되었습니다."),
-    BOOTH_REJECTED("부스 등록이 거부되었습니다.")
+    BOOTH_REJECTED("부스 등록이 거부되었습니다."),
+
+    RESERVE_APPROVED("예약 신청이 승인되었습니다."),
+    RESERVE_REJECTED("예약 신청이 거부되었습니다.")
 
     ;
 

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     // BAD REQUEST
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않습니다."),
     INVALID_BOOKMARK_TYPE(HttpStatus.BAD_REQUEST, "북마크 타입이 유효하지 않습니다."),
-    INVALID_RESERVATION_TYPE(HttpStatus.BAD_REQUEST, "북마크 타입이 유효하지 않습니다."),
+    INVALID_RESERVATION_TYPE(HttpStatus.BAD_REQUEST, "예약 타입이 유효하지 않습니다."),
 
     // CONFLICT
     ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     // BAD REQUEST
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않습니다."),
     INVALID_BOOKMARK_TYPE(HttpStatus.BAD_REQUEST, "북마크 타입이 유효하지 않습니다."),
+    INVALID_RESERVATION_TYPE(HttpStatus.BAD_REQUEST, "북마크 타입이 유효하지 않습니다."),
 
     // CONFLICT
     ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -145,11 +145,11 @@ public class BoothReservationService {
         if(status.equals(BoothReservationStatus.COMPLETE)){
             boothReservationDetail.updateUser(status, reserveUser);
             alarmService.createAlarm(manager, reserveUser,
-                    AlarmType.RESERVE_APPROVED, boothReservationDetail.getTime());
+                    AlarmType.RESERVE_APPROVED, boothReservationDetail.getLinkedReservation().getName());
         } else if (status.equals(BoothReservationStatus.EMPTY)) {
             boothReservationDetail.updateUser(status, null);
             alarmService.createAlarm(manager, reserveUser,
-                    AlarmType.RESERVE_REJECTED, boothReservationDetail.getTime());
+                    AlarmType.RESERVE_REJECTED, boothReservationDetail.getLinkedReservation().getName());
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -6,10 +6,12 @@ import com.openbook.openbook.domain.booth.dto.BoothReservationStatus;
 import com.openbook.openbook.domain.booth.dto.BoothStatus;
 import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.domain.booth.BoothReservation;
+import com.openbook.openbook.domain.user.dto.AlarmType;
 import com.openbook.openbook.repository.booth.BoothReservationRepository;
 import com.openbook.openbook.service.booth.dto.BoothReservationDto;
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
+import com.openbook.openbook.service.user.AlarmService;
 import com.openbook.openbook.util.S3Service;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.service.user.UserService;
@@ -32,6 +34,7 @@ public class BoothReservationService {
     private final BoothService boothService;
     private final BoothReservationDetailService reservationDetailService;
     private final BoothReservationRepository boothReservationRepository;
+    private final AlarmService alarmService;
 
 
     private Booth getValidBoothOrException(long userId, long boothId) {
@@ -125,5 +128,31 @@ public class BoothReservationService {
                 });
     }
 
+    @Transactional
+    public void changeReserveStatus(Long detailId, BoothReservationStatus status, Long userId){
+        BoothReservationDetail boothReservationDetail =
+                reservationDetailService.getReservationDetailOrException(detailId);
+        User manager = userService.getUserOrException(userId);
+        User reserveUser = boothReservationDetail.getUser();
+        VerifyUserIsManagerOfBooth(boothReservationDetail.getLinkedReservation().getLinkedBooth(), userId);
+        if(boothReservationDetail.getStatus().equals(status)){
+            throw new OpenBookException(ErrorCode.ALREADY_PROCESSED);
+        }
 
+        if(status.equals(BoothReservationStatus.COMPLETE)){
+            boothReservationDetail.updateUser(status, reserveUser);
+            alarmService.createAlarm(manager, reserveUser,
+                    AlarmType.RESERVE_APPROVED, boothReservationDetail.getTime());
+        } else if (status.equals(BoothReservationStatus.EMPTY)) {
+            boothReservationDetail.updateUser(status, null);
+            alarmService.createAlarm(manager, reserveUser,
+                    AlarmType.RESERVE_REJECTED, boothReservationDetail.getTime());
+        }
+    }
+
+    private void VerifyUserIsManagerOfBooth(Booth booth, long userId){
+        if(!booth.getManager().getId().equals(userId)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -132,9 +132,9 @@ public class BoothReservationService {
     public void changeReserveStatus(Long detailId, BoothReservationStatus status, Long userId){
         BoothReservationDetail boothReservationDetail =
                 reservationDetailService.getReservationDetailOrException(detailId);
+        VerifyUserIsManagerOfBooth(boothReservationDetail.getLinkedReservation().getLinkedBooth(), userId);
         User manager = userService.getUserOrException(userId);
         User reserveUser = boothReservationDetail.getUser();
-        VerifyUserIsManagerOfBooth(boothReservationDetail.getLinkedReservation().getLinkedBooth(), userId);
         if(boothReservationDetail.getStatus().equals(status)){
             throw new OpenBookException(ErrorCode.ALREADY_PROCESSED);
         }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.service.booth;
 
 import com.openbook.openbook.api.booth.request.ReserveRegistrationRequest;
+import com.openbook.openbook.api.booth.request.ReserveStatusUpdateRequest;
 import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import com.openbook.openbook.domain.booth.dto.BoothReservationStatus;
 import com.openbook.openbook.domain.booth.dto.BoothStatus;
@@ -129,12 +130,14 @@ public class BoothReservationService {
     }
 
     @Transactional
-    public void changeReserveStatus(Long detailId, BoothReservationStatus status, Long userId){
+    public void changeReserveStatus(Long detailId, ReserveStatusUpdateRequest request, Long userId){
         BoothReservationDetail boothReservationDetail =
                 reservationDetailService.getReservationDetailOrException(detailId);
         VerifyUserIsManagerOfBooth(boothReservationDetail.getLinkedReservation().getLinkedBooth(), userId);
         User manager = userService.getUserOrException(userId);
         User reserveUser = boothReservationDetail.getUser();
+        BoothReservationStatus status = BoothReservationStatus.fromString(request.status());
+
         if(boothReservationDetail.getStatus().equals(status)){
             throw new OpenBookException(ErrorCode.ALREADY_PROCESSED);
         }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -134,14 +134,15 @@ public class BoothReservationService {
         BoothReservationDetail boothReservationDetail =
                 reservationDetailService.getReservationDetailOrException(detailId);
         VerifyUserIsManagerOfBooth(boothReservationDetail.getLinkedReservation().getLinkedBooth(), userId);
-        User manager = userService.getUserOrException(userId);
-        User reserveUser = boothReservationDetail.getUser();
+
         BoothReservationStatus status = BoothReservationStatus.fromString(request.status());
 
         if(boothReservationDetail.getStatus().equals(status)){
             throw new OpenBookException(ErrorCode.ALREADY_PROCESSED);
         }
 
+        User manager = userService.getUserOrException(userId);
+        User reserveUser = boothReservationDetail.getUser();
         if(status.equals(BoothReservationStatus.COMPLETE)){
             boothReservationDetail.updateUser(status, reserveUser);
             alarmService.createAlarm(manager, reserveUser,


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #204 
PATCH /manage/booths/reserve/{detailId}
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- BoothReservationController에 부스 예약 상태를 변경하는 changeReserveStatus를 추가했습니다.
- ReserveStatusUpdateRequest 클래스를 만들어서 바꾸려는 상태를 요청받게 했습니다.
- BoothReservationService에 changeReserveStatus메서드를 추가해서 상태 정보를 update하는 기능을 구현했습니다.
- 관리자가 예약을 승인하거나 거부했을 경우 알람이 저장되도록 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
![image](https://github.com/user-attachments/assets/a2cb1789-54df-46e7-bd7c-e35b91077901)
- 로그인 한 유저가 해당 부스의 관리자가 아닐 경우
![image](https://github.com/user-attachments/assets/2244a0bd-9685-4225-9600-bd4935b090fb)
- 이미 요청한 상태일 경우
![image](https://github.com/user-attachments/assets/5b9f2463-2a07-480b-b7b7-ff353d2a3b7a)
- 상태가 변화한 후의 알람 저장 데이터
![image](https://github.com/user-attachments/assets/1ecfc881-fcb8-49cc-83b3-b188c3dec8bb)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- BoothReservationStatus의 종류가 EMPTY, WAITING, COMPLETE 이기 때문에 거부하는 요청은 EMPTY라고 했을 때 거부하게 하도록 했습니다. 따로 다른 의견 있으시면 말씀해주세요!
- 알람을 생성할 때 content 필드안에 예약한 시간의 정보를 넣었는데 다른 좋은 데이터 값 어떤게 있을 지 고민이 되었습니다! 혹시 생각나시는거 있으시면 의견 받겠습니다!
- 그 외 의견이나 질문 있으시면 리뷰 남겨 주세요!