### PR TITLE
Feat: 북마크한 행사와 부스 목록을 조회하는 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-devtools'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -34,8 +34,8 @@ public class BookmarkController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/bookmark")
-    public SliceResponse<BookmarkResponse> findBookmark(Authentication authentication,
+    @GetMapping("/bookmark-list")
+    public SliceResponse<BookmarkResponse> findBookmarkList(Authentication authentication,
                                                         @RequestParam(value = "type") String request,
                                                         Pageable pageable) {
         return SliceResponse.of(bookmarkService

--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -8,8 +8,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +27,12 @@ public class BookmarkController {
                                     @Valid @RequestBody BookmarkRequest request) {
         bookmarkService.createBookmark(Long.parseLong(authentication.getName()), request);
         return new ResponseMessage("북마크에 성공했습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/bookmark")
+    public void findBookmark(Authentication authentication, @RequestParam(value = "type") String request) {
+
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -2,10 +2,14 @@ package com.openbook.openbook.api.user;
 
 
 import com.openbook.openbook.api.ResponseMessage;
+import com.openbook.openbook.api.SliceResponse;
 import com.openbook.openbook.api.user.request.BookmarkRequest;
+import com.openbook.openbook.api.user.response.BookmarkResponse;
 import com.openbook.openbook.service.user.BookmarkService;
+import com.openbook.openbook.service.user.dto.BookmarkDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,8 +35,13 @@ public class BookmarkController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/bookmark")
-    public void findBookmark(Authentication authentication, @RequestParam(value = "type") String request) {
-
+    public SliceResponse<BookmarkResponse> findBookmark(Authentication authentication,
+                                                        @RequestParam(value = "type") String request,
+                                                        Pageable pageable) {
+        return SliceResponse.of(bookmarkService
+                .findBookmarkList(Long.parseLong(authentication.getName()), request, pageable)
+                .map(BookmarkResponse::of)
+        );
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/user/response/BookmarkResponse.java
+++ b/src/main/java/com/openbook/openbook/api/user/response/BookmarkResponse.java
@@ -1,0 +1,24 @@
+package com.openbook.openbook.api.user.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.openbook.openbook.api.booth.response.BoothBasicData;
+import com.openbook.openbook.api.event.response.UserEventData;
+import com.openbook.openbook.domain.user.dto.BookmarkType;
+import com.openbook.openbook.service.user.dto.BookmarkDto;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BookmarkResponse(
+        long id,
+        String bookmarkType,
+        UserEventData event,
+        BoothBasicData booth
+) {
+    public static BookmarkResponse of(BookmarkDto bookmark) {
+        return new BookmarkResponse(
+                bookmark.id(),
+                bookmark.type().name(),
+                (bookmark.type()== BookmarkType.EVENT) ? UserEventData.of(bookmark.event()) : null,
+                (bookmark.type()== BookmarkType.BOOTH) ? BoothBasicData.of(bookmark.booth()) : null
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
@@ -2,6 +2,8 @@ package com.openbook.openbook.repository.user;
 
 import com.openbook.openbook.domain.user.Bookmark;
 import com.openbook.openbook.domain.user.dto.BookmarkType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByUserIdAndResourceIdAndBookmarkType(long userId, long resourceId, BookmarkType type);
+
+    Slice<Bookmark> findAllByUserIdAndBookmarkType(long userId, BookmarkType type, Pageable pageable);
 
 }

--- a/src/main/java/com/openbook/openbook/service/user/dto/BookmarkDto.java
+++ b/src/main/java/com/openbook/openbook/service/user/dto/BookmarkDto.java
@@ -1,0 +1,22 @@
+package com.openbook.openbook.service.user.dto;
+
+import com.openbook.openbook.domain.user.Bookmark;
+import com.openbook.openbook.domain.user.dto.BookmarkType;
+import com.openbook.openbook.service.booth.dto.BoothDto;
+import com.openbook.openbook.service.event.dto.EventDto;
+
+public record BookmarkDto(
+        long id,
+        BookmarkType type,
+        EventDto event,
+        BoothDto booth
+) {
+    public static BookmarkDto of(Bookmark bookmark, EventDto event, BoothDto booth) {
+        return new BookmarkDto(
+                bookmark.getId(),
+                bookmark.getBookmarkType(),
+                event,
+                booth
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #220 

북마크한 행사나 부스 목록을 조회하는 API 를 개발했습니다.

API
- GET
- /bookmark-list

Param
- type (EVENT/BOOTH)
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- Build: @JsonInclude 를 사용하기 위해 필요한 의존성을 추가했습니다.
- 북마크 정보를 담기 위한 객체를 생성했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**성공**
- GET /bookmark-list?type=EVENT
- ![image](https://github.com/user-attachments/assets/369b0a6e-9032-4b5e-a400-12411f8c1621)

**실패: 파라미터 입력하지 않았을 경우**
- GET /bookmark-list 
- ![image](https://github.com/user-attachments/assets/3a8e5d19-85b7-4dbe-af73-453e7b809d0c)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 현재는 파라미터를 부스와 이벤트로 나눠 무조건 동일한 타입만 반환 되도록 했지만, 두 정보가 섞여서 반환 되는 값도 필요하면 해당 작업은 추후 추가적으로 진행하면 될 것 같아요. 해당 내용은 다음 회의 때 물어보도록 하겠습니다!
- 데이터 특성 상 행사와 부스의 응답 데이터를 다 사용하고 있는데, 두 기본 응답 객체 명이 UserEventData, BoothBasicData 더라구요. 해당 객체 명을 규칙을 세워 통일시키면 좋을 것 같다는 생각이 들었습니다! 어떻게 수정하면 좋을지 같이 생각해보면 좋을 것 같아요!
- 궁금하신 점이나 개선할 점 등 의견 편하게 주세요! 😃