### PR TITLE
Feat: 북마크를 취소하는 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -6,12 +6,12 @@ import com.openbook.openbook.api.SliceResponse;
 import com.openbook.openbook.api.user.request.BookmarkRequest;
 import com.openbook.openbook.api.user.response.BookmarkResponse;
 import com.openbook.openbook.service.user.BookmarkService;
-import com.openbook.openbook.service.user.dto.BookmarkDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +31,14 @@ public class BookmarkController {
                                     @Valid @RequestBody BookmarkRequest request) {
         bookmarkService.createBookmark(Long.parseLong(authentication.getName()), request);
         return new ResponseMessage("북마크에 성공했습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/bookmark")
+    public ResponseMessage bookmarkCancel(Authentication authentication,
+                                          @Valid @RequestBody BookmarkRequest request) {
+        bookmarkService.deleteBookmark(Long.parseLong(authentication.getName()), request);
+        return new ResponseMessage("북마크 취소에 성공했습니다.");
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰 정보를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "북마크 정보를 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약 정보를 찾을 수 없습니다."),
 
     // INTERNET SERVER ERROR

--- a/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/user/BookmarkRepository.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.repository.user;
 
 import com.openbook.openbook.domain.user.Bookmark;
 import com.openbook.openbook.domain.user.dto.BookmarkType;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Repository;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByUserIdAndResourceIdAndBookmarkType(long userId, long resourceId, BookmarkType type);
+
+    Optional<Bookmark> findByUserIdAndResourceIdAndBookmarkType(Long user_id, Long resourceId, BookmarkType bookmarkType);
 
     Slice<Bookmark> findAllByUserIdAndBookmarkType(long userId, BookmarkType type, Pageable pageable);
 

--- a/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
+++ b/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
@@ -57,4 +57,13 @@ public class BookmarkService {
         });
     }
 
+    @Transactional
+    public void deleteBookmark(long userId, BookmarkRequest request) {
+        Bookmark bookmark = bookmarkRepository.findByUserIdAndResourceIdAndBookmarkType(
+                userId, request.resourceId(), BookmarkType.fromString(request.type())).orElseThrow(()->
+                new OpenBookException(ErrorCode.BOOKMARK_NOT_FOUND)
+        );
+        bookmarkRepository.delete(bookmark);
+    }
+
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #223 

북마크를 삭제 (취소) 하는 API 를 개발했습니다.

API
- DELETE
- /bookmark

Body
- type
- resourceId
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 일치하는 북마크가 없는 경우의 에러 코드 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
DELETE /bookmark

**성공 예**
```
{
    "type":"EVENT",
    "resourceId":60
}
```
![image](https://github.com/user-attachments/assets/4b81cfd0-6102-4ffc-80f6-036fafd0bc44)

**실패 예: 북마크하지 않은 리소스의 경우**
```
{
    "type":"EVENT",
    "resourceId":61
}
```
![image](https://github.com/user-attachments/assets/5f2c354e-61d5-4e61-bf21-c8f8a0c1f261)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 원래 북마크 id를 받아서 삭제하려고 했는데, 현재 북마크 목록을 조회해야만 id 를 볼 수 있어서 그냥 타입과 리소스 아이디를 통해 찾아서 삭제하도록 구현했습니다. 이 때 생성하는 객체와 따로 구분하지 않고 Request 객체를 공통으로 사용했습니다.
- 현재는 DELETE 를 통해 삭제를 따로 구현했고 이렇게 구현한 프로젝트도 많지만 어떤 곳은 그냥 생성과 삭제를 POST 요청으로 없으면 생성, 있으면 삭제하는 방식으로 한번에 하더라구요. 고민하다가 일단은 DELETE 요청의 API로 따로 구현했는데 이에 관련해서 의견 생각나시면 말씀해주시면 감사하겠습니다!
- 성공 시의 반환 메서드를 "삭제에 성공했습니다." 가 아닌 "취소에 성공했습니다." 라고 했는데 어느 쪽이 나을지 의견을 듣고 싶습니다! 위에 작성한 것처럼 한 요청으로 북마크 추가와 취소를 같이 하면 취소가 맞을 것 같은데 삭제하는 것으로 나눴으니 그냥 삭제가 맞는가 싶기도 하더라고요. 의견 주시면 감사하겠습니다!
- 기타 궁금한 점, 개선할 점 등 의견 편하게 주세요! 😃