### PR TITLE
Fix: 이미 존재하는 예약의 동일 날짜를 가진 새 예약을 등록할 경우

### DIFF
--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
@@ -4,9 +4,15 @@ import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface BoothReservationDetailRepository extends JpaRepository<BoothReservationDetail, Long> {
     List<BoothReservationDetail> findBoothReservationDetailsByLinkedReservationId(Long reservationId);
+    boolean existsByTime(String date);
+
+    boolean existsByLinkedReservation_DateAndTime(LocalDate date, String time);
+
+    List<BoothReservationDetail> findBoothReservationDetailsByTime(String time);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
@@ -1,6 +1,5 @@
 package com.openbook.openbook.repository.booth;
 
-import com.openbook.openbook.domain.booth.BoothReservation;
 import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,6 +7,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothReservationDetailRepository extends JpaRepository<BoothReservationDetail, Long> {
-
-    BoothReservationDetail findByLinkedReservation(BoothReservation boothReservation);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
@@ -4,14 +4,7 @@ import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
-import java.util.List;
-
 @Repository
 public interface BoothReservationDetailRepository extends JpaRepository<BoothReservationDetail, Long> {
     boolean existsByTime(String date);
-
-    boolean existsByLinkedReservation_NameAndTime(String name, String time);
-
-    List<BoothReservationDetail> findBoothReservationDetailsByTime(String time);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @Repository
 public interface BoothReservationDetailRepository extends JpaRepository<BoothReservationDetail, Long> {
-    List<BoothReservationDetail> findBoothReservationDetailsByLinkedReservationId(Long reservationId);
     boolean existsByTime(String date);
 
     boolean existsByLinkedReservation_NameAndTime(String name, String time);

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
@@ -1,10 +1,13 @@
 package com.openbook.openbook.repository.booth;
 
+import com.openbook.openbook.domain.booth.BoothReservation;
 import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+
 @Repository
 public interface BoothReservationDetailRepository extends JpaRepository<BoothReservationDetail, Long> {
-    boolean existsByTime(String date);
+
+    BoothReservationDetail findByLinkedReservation(BoothReservation boothReservation);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationDetailRepository.java
@@ -12,7 +12,7 @@ public interface BoothReservationDetailRepository extends JpaRepository<BoothRes
     List<BoothReservationDetail> findBoothReservationDetailsByLinkedReservationId(Long reservationId);
     boolean existsByTime(String date);
 
-    boolean existsByLinkedReservation_DateAndTime(LocalDate date, String time);
+    boolean existsByLinkedReservation_NameAndTime(String name, String time);
 
     List<BoothReservationDetail> findBoothReservationDetailsByTime(String time);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
@@ -1,6 +1,5 @@
 package com.openbook.openbook.repository.booth;
 
-import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.domain.booth.BoothReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.repository.booth;
 
+import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.domain.booth.BoothReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,5 @@ import java.util.List;
 @Repository
 public interface BoothReservationRepository extends JpaRepository<BoothReservation, Long> {
     List<BoothReservation> findBoothReservationByLinkedBoothId(Long boothId);
-    boolean existsByDateAndName(LocalDate date, String name);
+    boolean existsByLinkedBoothIdAndDateAndName(Long boothId, LocalDate date, String name);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
@@ -4,9 +4,11 @@ import com.openbook.openbook.domain.booth.BoothReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface BoothReservationRepository extends JpaRepository<BoothReservation, Long> {
     List<BoothReservation> findBoothReservationByLinkedBoothId(Long boothId);
+    boolean existsByDateAndName(LocalDate date, String name);
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReservationRepository.java
@@ -1,15 +1,12 @@
 package com.openbook.openbook.repository.booth;
 
-import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.domain.booth.BoothReservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface BoothReservationRepository extends JpaRepository<BoothReservation, Long> {
-    boolean existsByDateAndLinkedBooth(LocalDate date, Booth booth);
     List<BoothReservation> findBoothReservationByLinkedBoothId(Long boothId);
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -25,9 +25,16 @@ public class BoothReservationDetailService {
         );
     }
 
-    public void createReservationDetail(List<String> reservationDetails, BoothReservation reservation){
-        checkExistDetail(reservationDetails, reservation);
+    public boolean hasExistTime(List<String> times){
+        for(String time : times){
+            if(!boothReservationDetailRepository.existsByTime(time)){
+                return false;
+            }
+        }
+        return true;
+    }
 
+    public void createReservationDetail(List<String> reservationDetails, BoothReservation reservation){
         for(String time : reservationDetails){
             boothReservationDetailRepository.save(
                     BoothReservationDetail.builder()
@@ -35,19 +42,6 @@ public class BoothReservationDetailService {
                             .time(time)
                             .build()
             );
-        }
-    }
-
-    private void checkExistDetail(List<String> times, BoothReservation reservation){
-        for(String time : times){
-            if(boothReservationDetailRepository.existsByTime(time)) {
-                List<BoothReservationDetail> details = boothReservationDetailRepository.findBoothReservationDetailsByTime(time);
-                for(BoothReservationDetail detail : details){
-                    if(boothReservationDetailRepository.existsByLinkedReservation_NameAndTime(reservation.getName(), detail.getTime())){
-                        throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
-                    }
-                }
-            }
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.service.booth;
 
+import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.domain.booth.BoothReservation;
 import com.openbook.openbook.domain.booth.BoothReservationDetail;
 import com.openbook.openbook.domain.booth.dto.BoothReservationStatus;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.List;
 
 @Service
@@ -25,23 +27,25 @@ public class BoothReservationDetailService {
         );
     }
 
-    public boolean hasExistTime(List<String> times){
-        for(String time : times){
-            if(!boothReservationDetailRepository.existsByTime(time)){
-                return false;
-            }
-        }
-        return true;
-    }
+    public void createReservationDetail(List<String> times, BoothReservation reservation, Booth booth){
+        checkAvailableTime(times, booth);
 
-    public void createReservationDetail(List<String> reservationDetails, BoothReservation reservation){
-        for(String time : reservationDetails){
+        for(String time : times){
             boothReservationDetailRepository.save(
                     BoothReservationDetail.builder()
                             .boothReservation(reservation)
                             .time(time)
                             .build()
             );
+        }
+    }
+
+    private void checkAvailableTime(List<String> times, Booth booth){
+        for(String time : times){
+            if(booth.getOpenTime().toLocalTime().isAfter(LocalTime.parse(time))
+                    || booth.getCloseTime().toLocalTime().isBefore(LocalTime.parse(time))){
+                throw new OpenBookException(ErrorCode.UNAVAILABLE_RESERVED_TIME);
+            }
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -26,7 +26,7 @@ public class BoothReservationDetailService {
     }
 
     public void createReservationDetail(List<String> reservationDetails, BoothReservation reservation){
-        checkExistTime(reservationDetails, reservation);
+        checkExistDetail(reservationDetails, reservation);
 
         for(String time : reservationDetails){
             boothReservationDetailRepository.save(
@@ -38,12 +38,12 @@ public class BoothReservationDetailService {
         }
     }
 
-    private void checkExistTime(List<String> times, BoothReservation reservation){
+    private void checkExistDetail(List<String> times, BoothReservation reservation){
         for(String time : times){
             if(boothReservationDetailRepository.existsByTime(time)) {
                 List<BoothReservationDetail> details = boothReservationDetailRepository.findBoothReservationDetailsByTime(time);
                 for(BoothReservationDetail detail : details){
-                    if(boothReservationDetailRepository.existsByLinkedReservation_DateAndTime(reservation.getDate(), detail.getTime())){
+                    if(boothReservationDetailRepository.existsByLinkedReservation_NameAndTime(reservation.getName(), detail.getTime())){
                         throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
                     }
                 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -31,7 +31,6 @@ public class BoothReservationDetailService {
 
     public void createReservationDetail(List<String> times, BoothReservation reservation, Booth booth){
         checkAvailableTime(times, booth);
-        checkDuplicateTime(times);
 
         for(String time : times){
             boothReservationDetailRepository.save(
@@ -44,19 +43,14 @@ public class BoothReservationDetailService {
     }
 
     private void checkAvailableTime(List<String> times, Booth booth){
-        for(String time : times){
-            if(booth.getOpenTime().toLocalTime().isAfter(LocalTime.parse(time))
-                    || booth.getCloseTime().toLocalTime().isBefore(LocalTime.parse(time))){
-                throw new OpenBookException(ErrorCode.UNAVAILABLE_RESERVED_TIME);
-            }
-        }
-    }
-
-    private void checkDuplicateTime(List<String> times){
         Set<String> validTimes = new HashSet<>();
         times.stream()
                 .map(String::trim)
                 .forEach(time -> {
+                    if(booth.getOpenTime().toLocalTime().isAfter(LocalTime.parse(time))
+                            || booth.getCloseTime().toLocalTime().isBefore(LocalTime.parse(time))){
+                        throw new OpenBookException(ErrorCode.UNAVAILABLE_RESERVED_TIME);
+                    }
                     if(!validTimes.add(time)){
                         throw new OpenBookException(ErrorCode.DUPLICATE_RESERVED_TIME);
                     }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -51,10 +51,6 @@ public class BoothReservationDetailService {
         }
     }
 
-    public List<BoothReservationDetail> getDetailsOfReservation(Long reservationId){
-        return boothReservationDetailRepository.findBoothReservationDetailsByLinkedReservationId(reservationId);
-    }
-
     @Transactional
     public void setUserToReservation(User user, BoothReservationDetail boothReservationDetail){
         boothReservationDetail.updateUser(BoothReservationStatus.WAITING, user);

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -26,6 +26,8 @@ public class BoothReservationDetailService {
     }
 
     public void createReservationDetail(List<String> reservationDetails, BoothReservation reservation){
+        checkExistTime(reservationDetails, reservation);
+
         for(String time : reservationDetails){
             boothReservationDetailRepository.save(
                     BoothReservationDetail.builder()
@@ -33,6 +35,19 @@ public class BoothReservationDetailService {
                             .time(time)
                             .build()
             );
+        }
+    }
+
+    private void checkExistTime(List<String> times, BoothReservation reservation){
+        for(String time : times){
+            if(boothReservationDetailRepository.existsByTime(time)) {
+                List<BoothReservationDetail> details = boothReservationDetailRepository.findBoothReservationDetailsByTime(time);
+                for(BoothReservationDetail detail : details){
+                    if(boothReservationDetailRepository.existsByLinkedReservation_DateAndTime(reservation.getDate(), detail.getTime())){
+                        throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationDetailService.java
@@ -13,7 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +31,7 @@ public class BoothReservationDetailService {
 
     public void createReservationDetail(List<String> times, BoothReservation reservation, Booth booth){
         checkAvailableTime(times, booth);
+        checkDuplicateTime(times);
 
         for(String time : times){
             boothReservationDetailRepository.save(
@@ -47,6 +50,17 @@ public class BoothReservationDetailService {
                 throw new OpenBookException(ErrorCode.UNAVAILABLE_RESERVED_TIME);
             }
         }
+    }
+
+    private void checkDuplicateTime(List<String> times){
+        Set<String> validTimes = new HashSet<>();
+        times.stream()
+                .map(String::trim)
+                .forEach(time -> {
+                    if(!validTimes.add(time)){
+                        throw new OpenBookException(ErrorCode.DUPLICATE_RESERVED_TIME);
+                    }
+                });
     }
 
     @Transactional

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -84,9 +84,7 @@ public class BoothReservationService {
     @Transactional
     public void addReservation(Long userId, ReserveRegistrationRequest request, Long boothId) {
         Booth booth = getValidBoothOrException(userId, boothId);
-        if (hasExistDate(request.date(), booth)) {
-            throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
-        }
+        
         if(request.date().isBefore(booth.getLinkedEvent().getOpenDate())
                 || request.date().isAfter(booth.getLinkedEvent().getCloseDate())){
             throw new OpenBookException(ErrorCode.INVALID_RESERVED_DATE);

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -17,8 +17,6 @@ import com.openbook.openbook.util.S3Service;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.service.user.UserService;
 import java.time.LocalTime;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -110,11 +110,8 @@ public class BoothReservationService {
     }
 
     private void checkDuplicateDates(ReserveRegistrationRequest request, Booth booth){
-        List<BoothReservation> reservations = getBoothReservations(booth.getId());
-        for(BoothReservation reservation : reservations){
-            if(reservation.getDate().equals(request.date()) && reservation.getName().equals(request.name())){
-                throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
-            }
+        if(boothReservationRepository.existsByLinkedBoothIdAndDateAndName(booth.getId(), request.date(), request.name())){
+            throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -83,10 +83,7 @@ public class BoothReservationService {
     public void addReservation(Long userId, ReserveRegistrationRequest request, Long boothId) {
         Booth booth = getValidBoothOrException(userId, boothId);
 
-        if(request.date().isBefore(booth.getLinkedEvent().getOpenDate())
-                || request.date().isAfter(booth.getLinkedEvent().getCloseDate())){
-            throw new OpenBookException(ErrorCode.INVALID_RESERVED_DATE);
-        }
+        checkAvailableDate(request, booth);
         checkAvailableTime(request, booth);
         checkDuplicateTimes(request.times());
 
@@ -106,6 +103,13 @@ public class BoothReservationService {
 
     public List<BoothReservation> getBoothReservations(Long boothId){
         return boothReservationRepository.findBoothReservationByLinkedBoothId(boothId);
+    }
+
+    private void checkAvailableDate(ReserveRegistrationRequest request, Booth booth){
+        if(request.date().isBefore(booth.getLinkedEvent().getOpenDate())
+                || request.date().isAfter(booth.getLinkedEvent().getCloseDate())){
+            throw new OpenBookException(ErrorCode.INVALID_RESERVED_DATE);
+        }
     }
 
     private void checkAvailableTime(ReserveRegistrationRequest request, Booth booth){


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #226

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- reservation 객체를 저장하기 전 createReservationDetail 메소드에서 날짜 오류처리를 한 후 객체를 db에 저장하도록 했습니다.
- checkExistTime 메소드에서는 입력 받은 시간들중 이미 존재하는 시간이 있는 boothReservationDetail 객체 리스트를 조회해서 그 객체들 안에서 시간과 날짜가 모두 일치하는 detail 데이터가 존재할 경우 오류처리를 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 같은 날짜의 다른 시간 데이터를 저장할 경우 저장이 되는 것을 확인했습니다.
- 같은 날짜에 같은 시간의 데이터를 요청할 경우 오류 처리가 됩니다.
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 구현하면서 생각이 든건데 이렇게 되더라도 만약 등록하고자 하는 완전히 다른 예약 서비스를 새로 등록하고자 할 때 이전에 등록한 예약 서비스의 시간과 날짜가 완전히 같을 경우에는 오류처리가 되는 것은 동일 한 것 같아 고민이 되네요 ..! 
예를 들어, 어떠한 부스에 A 예약 서비스에 (9/10 [01:00, 02:00] , 9/11 [10:00, 12:00]) 으로 등록이 이미 되어 있고 새로 B 예약 서비스를 등록 할 때 날짜와 시간이 (9/09 [10:00, 11:00], 9/10 [01:00]) 이렇게 등록하고 싶을 경우 9/10 01:00 의 데이터가 겹치게 되어 오류가 나타나는 상황에 문제가 될 수 있겠네요!
혹시 이 부분에 대해 의견 말씀해주신다면 감사하겠습니다! 😊
- 추가로 의견이나 질문사항 있으시면 리뷰 남겨주세요!