### PR TITLE
Feat: 부스 리뷰 목록 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
@@ -13,10 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +29,7 @@ public class BoothReviewController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("부스 리뷰 작성에 성공했습니다."));
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booth/reviews")
     public SliceResponse<BoothReviewResponse> getReviews(@RequestParam(value = "booth_id") Long boothId,
                                                          @PageableDefault(size = 5) Pageable pageable){

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
@@ -1,15 +1,21 @@
 package com.openbook.openbook.api.booth;
 
 
+import com.openbook.openbook.api.SliceResponse;
 import com.openbook.openbook.api.booth.request.BoothReviewRegisterRequest;
+import com.openbook.openbook.api.booth.response.BoothReviewResponse;
 import com.openbook.openbook.service.booth.BoothReviewService;
 import com.openbook.openbook.api.ResponseMessage;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +30,11 @@ public class BoothReviewController {
                                                       @Valid BoothReviewRegisterRequest request){
         boothReviewService.registerBoothReview(Long.valueOf(authentication.getName()), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("부스 리뷰 작성에 성공했습니다."));
+    }
+
+    @GetMapping("/booth/reviews")
+    public SliceResponse<BoothReviewResponse> getReviews(@RequestParam(value = "booth_id") Long boothId,
+                                                         @PageableDefault(size = 5) Pageable pageable){
+        return SliceResponse.of(boothReviewService.getBoothReviews(boothId, pageable).map(BoothReviewResponse::of));
     }
 }

--- a/src/main/java/com/openbook/openbook/api/booth/response/BoothReviewResponse.java
+++ b/src/main/java/com/openbook/openbook/api/booth/response/BoothReviewResponse.java
@@ -1,0 +1,26 @@
+package com.openbook.openbook.api.booth.response;
+
+import com.openbook.openbook.api.user.response.UserPublicResponse;
+import com.openbook.openbook.service.booth.dto.BoothReviewDto;
+
+import java.time.LocalDateTime;
+
+public record BoothReviewResponse(
+        UserPublicResponse reviewer,
+        long id,
+        float star,
+        String content,
+        String image,
+        LocalDateTime registerDate
+) {
+    public static BoothReviewResponse of(BoothReviewDto boothReviewDto){
+        return new BoothReviewResponse(
+                UserPublicResponse.of(boothReviewDto.reviewer()),
+                boothReviewDto.id(),
+                boothReviewDto.star(),
+                boothReviewDto.content(),
+                boothReviewDto.image(),
+                boothReviewDto.registerAt()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/configuration/SecurityConfig.java
+++ b/src/main/java/com/openbook/openbook/configuration/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
             "/events/{event_id}/notices",
             "/events/notices/{notice_id}",
             "/event/reviews",
-            "/events/search"
+            "/events/search",
+            "/booth/reviews"
     };
 
     @Bean

--- a/src/main/java/com/openbook/openbook/configuration/SecurityConfig.java
+++ b/src/main/java/com/openbook/openbook/configuration/SecurityConfig.java
@@ -34,13 +34,13 @@ public class SecurityConfig {
             "/booths/{booth_id}/products",
             "/booths/products/category",
             "/booths/{booth_id}/reservations",
+            "/booth/reviews",
             "/events",
             "/events/{eventId}",
             "/events/{event_id}/notices",
             "/events/notices/{notice_id}",
             "/event/reviews",
-            "/events/search",
-            "/booth/reviews"
+            "/events/search"
     };
 
     @Bean

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReviewRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReviewRepository.java
@@ -1,9 +1,12 @@
 package com.openbook.openbook.repository.booth;
 
 import com.openbook.openbook.domain.booth.BoothReview;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothReviewRepository extends JpaRepository<BoothReview, Long> {
+    Slice<BoothReview> findBoothReviewsByLinkedBoothId(long boothId, Pageable pageable);
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
@@ -7,11 +7,14 @@ import com.openbook.openbook.domain.booth.BoothReview;
 import com.openbook.openbook.repository.booth.BoothReviewRepository;
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
+import com.openbook.openbook.service.booth.dto.BoothReviewDto;
 import com.openbook.openbook.util.S3Service;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.service.user.UserService;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +45,16 @@ public class BoothReviewService {
                 .imageUrl(s3Service.uploadFileAndGetUrl(request.image()))
                 .build()
         );
+    }
+
+    @Transactional
+    public Slice<BoothReviewDto> getBoothReviews(long boothId, Pageable pageable){
+        Booth booth = boothService.getBoothOrException(boothId);
+        if(!booth.getStatus().equals(BoothStatus.APPROVE)){
+            throw new OpenBookException(ErrorCode.BOOTH_NOT_APPROVED);
+        }
+
+        return boothReviewRepository.findBoothReviewsByLinkedBoothId(boothId, pageable).map(BoothReviewDto::of);
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/booth/dto/BoothReviewDto.java
+++ b/src/main/java/com/openbook/openbook/service/booth/dto/BoothReviewDto.java
@@ -1,14 +1,29 @@
 package com.openbook.openbook.service.booth.dto;
 
 import com.openbook.openbook.domain.booth.Booth;
-import com.openbook.openbook.domain.user.User;
-import org.springframework.web.multipart.MultipartFile;
+import com.openbook.openbook.domain.booth.BoothReview;
+import com.openbook.openbook.service.user.dto.UserDto;
+
+import java.time.LocalDateTime;
 
 public record BoothReviewDto(
-        User reviewer,
+        UserDto reviewer,
         Booth linkedBooth,
+        long id,
         float star,
         String content,
-        MultipartFile image
+        String image,
+        LocalDateTime registerAt
 ) {
+    public static BoothReviewDto of(BoothReview review){
+        return new BoothReviewDto(
+                UserDto.of(review.getReviewer()),
+                review.getLinkedBooth(),
+                review.getId(),
+                review.getStar(),
+                review.getContent(),
+                review.getImageUrl(),
+                review.getRegisteredAt()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #228 
GET /booth/reviews?booth_id={boothId}

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 부스 리뷰 정보를 응답하기 위한 BoothReviewResponse 클래스를 추가했습니다.
- Slice를 이용해서 조회 한 리뷰 정보를 무한 스크롤링 하도록 했습니다.
- 부스 목록 조회는 로그인이 따로 필요 없는 기능이기 때문에 SecurityConfig에 경로를 추가했습니다.

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
![스크린샷 2024-09-23 오전 12 58 08](https://github.com/user-attachments/assets/6a960802-93d0-4c65-aa60-0229819608be)
- 존재하지 않는 부스의 리뷰를 조회할 경우
![image](https://github.com/user-attachments/assets/b904b434-c441-408a-9abf-b65a8c3beb95)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금한점이나 의견있으시면 리뷰 남겨주세요!