### PR TITLE
Feat: 행사 리뷰를 수정하는 기능

### DIFF
--- a/src/main/java/com/openbook/openbook/api/event/EventReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/event/EventReviewController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,7 +48,7 @@ public class EventReviewController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @PatchMapping("/event/reviews/{review_id}")
+    @PutMapping("/event/reviews/{review_id}")
     public ResponseMessage modifyReview(Authentication authentication,
                                         @PathVariable Long review_id,
                                         @Valid EventReviewModifyRequest request) {

--- a/src/main/java/com/openbook/openbook/api/event/EventReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/event/EventReviewController.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.api.event;
 
+import com.openbook.openbook.api.event.request.EventReviewModifyRequest;
 import com.openbook.openbook.api.event.request.EventReviewRegisterRequest;
 import com.openbook.openbook.api.event.response.EventReviewResponse;
 import com.openbook.openbook.service.event.EventReviewService;
@@ -14,9 +15,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,6 +44,15 @@ public class EventReviewController {
     @GetMapping("/event/review/{review_id}")
     public ResponseEntity<EventReviewResponse> getReview(@PathVariable Long review_id) {
         return ResponseEntity.ok(EventReviewResponse.of(eventReviewService.getEventReview(review_id)));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/event/reviews/{review_id}")
+    public ResponseMessage modifyReview(Authentication authentication,
+                                        @PathVariable Long review_id,
+                                        @Valid EventReviewModifyRequest request) {
+        eventReviewService.modifyReview(Long.parseLong(authentication.getName()), review_id, request);
+        return new ResponseMessage("리뷰 수정에 성공했습니다.");
     }
 
     @DeleteMapping("/event/reviews/{review_id}")

--- a/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 public record EventReviewModifyRequest(
         @Max(value = 5) Float star,
         String content,
-        @Max(value = 5) List<MultipartFile> images
+        List<MultipartFile> imageToAdd,
+        List<Long> imageToDelete
 ) {
 }

--- a/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
@@ -1,0 +1,14 @@
+package com.openbook.openbook.api.event.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+@NotNull
+public record EventReviewModifyRequest(
+        @Max(value = 5) float star,
+        String content,
+        @Max(value = 5) List<MultipartFile> images
+) {
+}

--- a/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
@@ -7,7 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @NotNull
 public record EventReviewModifyRequest(
-        @Max(value = 5) float star,
+        @Max(value = 5) Float star,
         String content,
         @Max(value = 5) List<MultipartFile> images
 ) {

--- a/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/event/request/EventReviewModifyRequest.java
@@ -1,14 +1,14 @@
 package com.openbook.openbook.api.event.request;
 
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
-@NotNull
 public record EventReviewModifyRequest(
-        @Max(value = 5) Float star,
-        String content,
+        @NotNull @Max(value = 5) float star,
+        @NotBlank String content,
         List<MultipartFile> imageToAdd,
         List<Long> imageToDelete
 ) {

--- a/src/main/java/com/openbook/openbook/domain/event/EventReview.java
+++ b/src/main/java/com/openbook/openbook/domain/event/EventReview.java
@@ -49,4 +49,10 @@ public class EventReview extends EntityBasicTime {
         this.star = star;
         this.content = content;
     }
+
+    public void update(float star, String content) {
+        this.star = star;
+        this.content = content;
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),
     BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "북마크 정보를 찾을 수 없습니다."),
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약 정보를 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지 정보를 찾을 수 없습니다."),
 
     // INTERNET SERVER ERROR
     FIlE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.")

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     INACCESSIBLE_PERIOD(HttpStatus.CONFLICT, "접근 가능한 기간이 아닙니다."),
     UNDELETABLE_PERIOD(HttpStatus.CONFLICT, "삭제 가능한 기간이 아닙니다."),
     CANNOT_REVIEW_PERIOD(HttpStatus.CONFLICT, "리뷰 작성 가능한 기간이 아닙니다."),
+    EXCEED_MAXIMUM_IMAGE(HttpStatus.CONFLICT, "첨부할 수 있는 최대 사진 수를 초과했습니다."),
     ALREADY_RESERVED_AREA(HttpStatus.CONFLICT, "선택 가능한 구역이 아닙니다."),
     INVALID_DATE_RANGE(HttpStatus.CONFLICT, "입력된 날짜 범위가 유효하지 않습니다."),
     INVALID_LAYOUT_ENTRY(HttpStatus.CONFLICT, "입력된 배치도 형식에 오류가 있습니다."),

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -40,6 +40,12 @@ public class EventReviewService {
         );
     }
 
+    public EventReviewImage getEventReviewImageOrException(long eventReviewImageId) {
+        return eventReviewImageRepository.findById(eventReviewImageId).orElseThrow(()->
+                new OpenBookException(ErrorCode.IMAGE_NOT_FOUND)
+        );
+    }
+
     @Transactional(readOnly = true)
     public Slice<EventReviewDto> getEventReviews(final long eventId, final Pageable pageable) {
         Event event = eventService.getEventOrException(eventId);

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -79,6 +79,10 @@ public class EventReviewService {
 
     @Transactional
     public void modifyReview(long userId, long reviewId, EventReviewModifyRequest request) {
+        EventReview review = getEventReviewOrException(reviewId);
+        if(review.getReviewer().getId()!=userId) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
         
     }
 

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -15,6 +15,7 @@ import com.openbook.openbook.util.S3Service;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.service.user.UserService;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -87,6 +88,7 @@ public class EventReviewService {
                 (request.star()==null)?review.getStar():request.star(),
                 (request.content()==null)?review.getContent():request.content()
         );
+        modifyImage(request.imageToAdd(), request.imageToDelete(), review);
     }
 
     @Transactional
@@ -107,6 +109,9 @@ public class EventReviewService {
                         .imageOrder(order)
                         .build()
         );
+    }
+
+    private void modifyImage(List<MultipartFile> add, List<Long> delete, EventReview review) {
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -90,10 +90,7 @@ public class EventReviewService {
         if(review.getReviewer().getId()!=userId) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
-        review.update(
-                (request.star()==null)?review.getStar():request.star(),
-                (request.content()==null)?review.getContent():request.content()
-        );
+        review.update(request.star(), request.content());
         if(request.imageToAdd()!=null || request.imageToDelete()!=null) {
             modifyImage(request.imageToAdd(), request.imageToDelete(), review);
         }

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -128,6 +128,9 @@ public class EventReviewService {
             }
             eventReviewImageRepository.delete(image);
         });
+        for(int i=0;i<add.size();i++) {
+            createEventReviewImage(review, add.get(i), i);
+        }
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -112,6 +112,9 @@ public class EventReviewService {
     }
 
     private void modifyImage(List<MultipartFile> add, List<Long> delete, EventReview review) {
+        if(review.getReviewImages().size() - delete.size() + add.size() > 5) {
+            throw new OpenBookException(ErrorCode.EXCEED_MAXIMUM_IMAGE);
+        }
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -83,7 +83,10 @@ public class EventReviewService {
         if(review.getReviewer().getId()!=userId) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
-        
+        review.update(
+                (request.star()==null)?review.getStar():request.star(),
+                (request.content()==null)?review.getContent():request.content()
+        );
     }
 
     @Transactional

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.service.event;
 
+import com.openbook.openbook.api.event.request.EventReviewModifyRequest;
 import com.openbook.openbook.api.event.request.EventReviewRegisterRequest;
 import com.openbook.openbook.service.event.dto.EventReviewDto;
 import com.openbook.openbook.domain.event.Event;
@@ -74,6 +75,11 @@ public class EventReviewService {
                 createEventReviewImage(review, request.images().get(i), i);
             }
         }
+    }
+
+    @Transactional
+    public void modifyReview(long userId, long reviewId, EventReviewModifyRequest request) {
+        
     }
 
     @Transactional

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -121,6 +121,13 @@ public class EventReviewService {
         if(review.getReviewImages().size() - delete.size() + add.size() > 5) {
             throw new OpenBookException(ErrorCode.EXCEED_MAXIMUM_IMAGE);
         }
+        delete.forEach( imageId -> {
+            EventReviewImage image = getEventReviewImageOrException(imageId);
+            if(image.getLinkedReview()!=review) {
+                throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+            }
+            eventReviewImageRepository.delete(image);
+        });
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #198 

행사 리뷰를 수정하는 기능을 개발합니다.

[API]
- PUT
- /event/reviews/{review_id}

[Body(form-data)]
- star
- content
- imageToAdd
- imageToDelete

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 오류 처리에 필요한 에러 코드 생성
  - EXCEED_MAXIMUM_IMAGE: 최대 이미지 수를 넘긴 경우
  - IMAGE_NOT_FOUND: 이미지 id와 일치하는 엔티티가 없는 경우

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
테스트 요청 경로
- PUT {{local}}/event/reviews/4

성공
- ![image](https://github.com/user-attachments/assets/0ec947ad-329f-485e-8fee-b640f6978573)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- Patch 요청으로 구현할까 하다가 null 처리 관련해 복잡성을 줄이기 위해 Put 방식을 사용하였습니다.
- 현재 사진들의 seq 수정에 관련해서는 처리가 이루어지지 않는데요, 이 점에 대해서는 좀 더 생각해보고
추후 브런치를 통해 따로 구현하도록 하겠습니다! 😭
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요!