### PR TITLE
Feat: 부스 리뷰 삭제하는 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
@@ -43,4 +43,10 @@ public class BoothReviewController {
         return BoothReviewResponse.of(boothReviewService.getBoothReview(review_id));
 
     }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/booth/reviews/{review_id}")
+    public void deleteReview(Authentication authentication, @PathVariable Long review_id){
+        boothReviewService.deleteReview(Long.parseLong(authentication.getName()), review_id);
+    }
 }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
@@ -44,9 +44,10 @@ public class BoothReviewController {
 
     }
 
-    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/booth/reviews/{review_id}")
-    public void deleteReview(Authentication authentication, @PathVariable Long review_id){
+    public ResponseMessage deleteReview(Authentication authentication, @PathVariable Long review_id){
         boothReviewService.deleteReview(Long.parseLong(authentication.getName()), review_id);
+        return new ResponseMessage("부스 리뷰 삭제에 성공했습니다.");
     }
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
@@ -68,4 +68,13 @@ public class BoothReviewService {
         return BoothReviewDto.of(getBoothReviewOrException(reviewId));
     }
 
+    @Transactional
+    public void deleteReview(long userId, long reviewId){
+        BoothReview review = getBoothReviewOrException(reviewId);
+        if(review.getReviewer().getId() != userId){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        boothReviewRepository.deleteById(reviewId);
+    }
+
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #235
DELETE /booth/reviews/{review_id}
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 제거하려는 리뷰 아이디를 요청 받습니다.
- 제거하려는 리뷰 데이터를 찾아 삭제하는 메소드를 추가했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
<img width="745" alt="image" src="https://github.com/user-attachments/assets/645ac60a-08e9-42f7-8cc0-f49ec913292f">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- ResponseStatus 관련해서 처음에는 delete 요청에는 NO_CONTENT 상태로 두는 경우도 있다해서 204 상태로 두려다가 저희는 계속 성공 메세지를 반환 해왔었기 때문에 그냥 기존 200 상태로 변경했습니다. 제가 참고한 글 첨부해두겠습니다! 한번쯤 읽어보시면 좋을 것 같아요!
https://velog.io/@isayaksh/CS-Http-Status-code-204%EC%97%90-%EB%8C%80%ED%95%9C-%EA%B0%9C%EB%85%90%EA%B3%BC-%EC%82%AC%EC%9A%A9%EB%B0%A9%EB%B2%95
- 그외에 질문사항이나 의견 있으시면 리뷰 남겨주세요!