### PR TITLE
Feat: 부스 상품 삭제 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
@@ -14,10 +14,12 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -40,6 +42,13 @@ public class BoothProductController {
                                                       @Valid ProductRegistrationRequest request){
         boothProductService.addBoothProduct(Long.valueOf(authentication.getName()), booth_id, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("상품 추가에 성공했습니다."));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/booths/products/{product_id}")
+    public ResponseMessage deleteProduct(Authentication authentication, @PathVariable Long product_id) {
+        boothProductService.deleteProduct(Long.parseLong(authentication.getName()), product_id);
+        return new ResponseMessage("상품 삭제에 성공했습니다.");
     }
 
     @GetMapping("/booths/{booth_id}/product-category")

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     BOOTH_NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 공지 정보를 찾을 수 없습니다."),
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),
     PRODUCT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 카테고리를 찾을 수 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰 정보를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
@@ -112,6 +112,14 @@ public class BoothProductService {
         }
     }
 
+    @Transactional
+    public void deleteProduct(final long userId, final long productId) {
+        BoothProduct product = getBoothProductOrException(productId);
+        if(product.getLinkedCategory().getLinkedBooth().getManager().getId()!=userId) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        boothProductRepository.delete(product);
+    }
 
     public Slice<BoothProduct> getProductsByCategory(final BoothProductCategory category, final Pageable pageable) {
         return boothProductRepository.findAllByLinkedCategoryId(category.getId(), pageable);
@@ -120,8 +128,6 @@ public class BoothProductService {
     public List<BoothProductImage> getProductImages(final BoothProduct product) {
         return boothProductImageRepository.findAllByLinkedProductId(product.getId());
     }
-
-
 
     public void createBoothProductImage(final MultipartFile imageUrl, final BoothProduct boothProduct) {
         boothProductImageRepository.save(

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
@@ -144,4 +144,10 @@ public class BoothProductService {
         return booth;
     }
 
+    public BoothProduct getBoothProductOrException(final long productId) {
+        return boothProductRepository.findById(productId).orElseThrow(() ->
+                new OpenBookException(ErrorCode.PRODUCT_NOT_FOUND)
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #236 

부스 상품을 삭제하는 API를 개발했습니다.

**[API]** DELETE /booths/products/{product_id}
- 경로의 product_id 와 일치하는 부스 상품을 삭제합니다.
- 현재 로그인한 유저와 상품과 연결된 부스의 관리자가 일치하지 않는 경우 오류가 반환됩니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 상품이 없는 경우의 에러 코드 추가

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

요청: DELETE {{local}}/booths/products/9

**성공시**
- ![image](https://github.com/user-attachments/assets/fd5df5ff-eb6c-4d48-8b52-fc4d36cb9f53)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선 필요한 점 등 편하게 의견 주세요! 😃