### PR TITLE
Refactor: 행사 리뷰 이미지 서비스 분리

### DIFF
--- a/src/main/java/com/openbook/openbook/service/event/EventReviewImageService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewImageService.java
@@ -1,4 +1,54 @@
 package com.openbook.openbook.service.event;
 
+
+import com.openbook.openbook.domain.event.EventReview;
+import com.openbook.openbook.domain.event.EventReviewImage;
+import com.openbook.openbook.exception.ErrorCode;
+import com.openbook.openbook.exception.OpenBookException;
+import com.openbook.openbook.repository.event.EventReviewImageRepository;
+import com.openbook.openbook.util.S3Service;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
 public class EventReviewImageService {
+
+    private final EventReviewImageRepository eventReviewImageRepository;
+    private final S3Service s3Service;
+
+    public EventReviewImage getEventReviewImageOrException(long eventReviewImageId) {
+        return eventReviewImageRepository.findById(eventReviewImageId).orElseThrow(()->
+                new OpenBookException(ErrorCode.IMAGE_NOT_FOUND)
+        );
+    }
+
+    public void createEventReviewImage(EventReview linkedReview, MultipartFile image, int order){
+        eventReviewImageRepository.save(
+                EventReviewImage.builder()
+                        .linkedReview(linkedReview)
+                        .imageUrl(s3Service.uploadFileAndGetUrl(image))
+                        .imageOrder(order)
+                        .build()
+        );
+    }
+
+    public void modifyReviewImage(List<MultipartFile> add, List<Long> delete, EventReview review) {
+        int addSize = (add!=null)?add.size():0, deleteSize = (delete!=null)?delete.size():0;
+        if(review.getReviewImages().size() - deleteSize + addSize > 5) {
+            throw new OpenBookException(ErrorCode.EXCEED_MAXIMUM_IMAGE);
+        }
+        for(int i = 0; i < addSize; i++) {
+            createEventReviewImage(review, add.get(i), i);
+        }
+        for(int i = 0; i < deleteSize; i++) {
+            EventReviewImage image = getEventReviewImageOrException(delete.get(i));
+            if(image.getLinkedReview()!=review) {
+                throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+            }
+            eventReviewImageRepository.delete(image);
+        }
+    }
 }

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewImageService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewImageService.java
@@ -1,0 +1,4 @@
+package com.openbook.openbook.service.event;
+
+public class EventReviewImageService {
+}

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -5,44 +5,31 @@ import com.openbook.openbook.api.event.request.EventReviewRegisterRequest;
 import com.openbook.openbook.service.event.dto.EventReviewDto;
 import com.openbook.openbook.domain.event.Event;
 import com.openbook.openbook.domain.event.EventReview;
-import com.openbook.openbook.domain.event.EventReviewImage;
 import com.openbook.openbook.domain.event.dto.EventStatus;
-import com.openbook.openbook.repository.event.EventReviewImageRepository;
 import com.openbook.openbook.repository.event.EventReviewRepository;
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
-import com.openbook.openbook.util.S3Service;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.service.user.UserService;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class EventReviewService {
 
+    public final EventReviewImageService imageService;
     private final EventReviewRepository eventReviewRepository;
-    private final EventReviewImageRepository eventReviewImageRepository;
-    private final S3Service s3Service;
-
     private final UserService userService;
     private final EventService eventService;
 
     public EventReview getEventReviewOrException(long eventReviewId) {
         return eventReviewRepository.findById(eventReviewId).orElseThrow(()->
                 new OpenBookException(ErrorCode.REVIEW_NOT_FOUND)
-        );
-    }
-
-    public EventReviewImage getEventReviewImageOrException(long eventReviewImageId) {
-        return eventReviewImageRepository.findById(eventReviewImageId).orElseThrow(()->
-                new OpenBookException(ErrorCode.IMAGE_NOT_FOUND)
         );
     }
 
@@ -79,7 +66,7 @@ public class EventReviewService {
         );
         if(request.images() != null) {
             for(int i=0;i<request.images().size();i++) {
-                createEventReviewImage(review, request.images().get(i), i);
+                imageService.createEventReviewImage(review, request.images().get(i), i);
             }
         }
     }
@@ -92,7 +79,7 @@ public class EventReviewService {
         }
         review.update(request.star(), request.content());
         if(request.imageToAdd()!=null || request.imageToDelete()!=null) {
-            modifyImage(request.imageToAdd(), request.imageToDelete(), review);
+            imageService.modifyReviewImage(request.imageToAdd(), request.imageToDelete(), review);
         }
     }
 
@@ -103,35 +90,6 @@ public class EventReviewService {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         eventReviewRepository.deleteById(reviewId);
-    }
-
-
-    public void createEventReviewImage(EventReview linkedReview, MultipartFile image, int order){
-        eventReviewImageRepository.save(
-                EventReviewImage.builder()
-                        .linkedReview(linkedReview)
-                        .imageUrl(s3Service.uploadFileAndGetUrl(image))
-                        .imageOrder(order)
-                        .build()
-        );
-    }
-
-    private void modifyImage(List<MultipartFile> add, List<Long> delete, EventReview review) {
-        int addSize = (add!=null)?add.size():0;
-        int deleteSize = (delete!=null)?delete.size():0;
-        if(review.getReviewImages().size() - deleteSize + addSize > 5) {
-            throw new OpenBookException(ErrorCode.EXCEED_MAXIMUM_IMAGE);
-        }
-        for(int i = 0; i < addSize; i++) {
-            createEventReviewImage(review, add.get(i), i);
-        }
-        for(int i = 0; i < deleteSize; i++) {
-            EventReviewImage image = getEventReviewImageOrException(delete.get(i));
-            if(image.getLinkedReview()!=review) {
-                throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
-            }
-            eventReviewImageRepository.delete(image);
-        }
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #232 

기존의 행사 리뷰 서비스 안에 같이 존재하던 리뷰 이미지에 대한 기능을 이미지 서비스 클래스를 생성해 분리시켰습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- EventReviewImageService 를 추가 후 기존 EventReview 클래스에 있던 관련 메서드를 이동
- EventReview 에서 EventReviewImageService 로 이미지 기능을 호출하도록 변경

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
기존 관련 기능들이 문제 없이 실행됩니다.

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 다른 의견 있으시면 말씀해주세요! 😃