### PR TITLE
Fix: 이미 작성한 리뷰가 있는 경우 작성하지 못하도록 수정

### DIFF
--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -24,7 +24,10 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     INACCESSIBLE_PERIOD(HttpStatus.CONFLICT, "접근 가능한 기간이 아닙니다."),
     UNDELETABLE_PERIOD(HttpStatus.CONFLICT, "삭제 가능한 기간이 아닙니다."),
+
     CANNOT_REVIEW_PERIOD(HttpStatus.CONFLICT, "리뷰 작성 가능한 기간이 아닙니다."),
+    ALREADY_REVIEW(HttpStatus.CONFLICT, "이미 작성한 리뷰가 있습니다."),
+
     EXCEED_MAXIMUM_IMAGE(HttpStatus.CONFLICT, "첨부할 수 있는 최대 사진 수를 초과했습니다."),
     ALREADY_RESERVED_AREA(HttpStatus.CONFLICT, "선택 가능한 구역이 아닙니다."),
     INVALID_DATE_RANGE(HttpStatus.CONFLICT, "입력된 날짜 범위가 유효하지 않습니다."),
@@ -39,7 +42,6 @@ public enum ErrorCode {
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
     ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 시간 입니다."),
     ALREADY_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크 목록에 존재합니다."),
-
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),
 

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -26,7 +26,7 @@ public enum ErrorCode {
     UNDELETABLE_PERIOD(HttpStatus.CONFLICT, "삭제 가능한 기간이 아닙니다."),
 
     CANNOT_REVIEW_PERIOD(HttpStatus.CONFLICT, "리뷰 작성 가능한 기간이 아닙니다."),
-    ALREADY_REVIEW(HttpStatus.CONFLICT, "이미 작성한 리뷰가 있습니다."),
+    ALREADY_EXIST_REVIEW(HttpStatus.CONFLICT, "이미 작성한 리뷰가 있습니다."),
 
     EXCEED_MAXIMUM_IMAGE(HttpStatus.CONFLICT, "첨부할 수 있는 최대 사진 수를 초과했습니다."),
     ALREADY_RESERVED_AREA(HttpStatus.CONFLICT, "선택 가능한 구역이 아닙니다."),

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothReviewRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothReviewRepository.java
@@ -8,5 +8,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoothReviewRepository extends JpaRepository<BoothReview, Long> {
+
+    boolean existsByReviewerIdAndLinkedBoothId(Long reviewerId, Long linkedBoothId);
+
     Slice<BoothReview> findBoothReviewsByLinkedBoothId(long boothId, Pageable pageable);
 }

--- a/src/main/java/com/openbook/openbook/repository/event/EventReviewRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/event/EventReviewRepository.java
@@ -9,5 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EventReviewRepository extends JpaRepository<EventReview, Long> {
 
+    boolean existsByReviewerIdAndLinkedEventId(Long reviewerId, Long linkedEventId);
+
     Slice<EventReview> findByLinkedEventId(long eventId, Pageable pageable);
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
@@ -80,7 +80,7 @@ public class BoothReviewService {
             throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
         }
         if(boothReviewRepository.existsByReviewerIdAndLinkedBoothId(reviewerId, booth.getId())) {
-            throw new OpenBookException(ErrorCode.ALREADY_REVIEW);
+            throw new OpenBookException(ErrorCode.ALREADY_EXIST_REVIEW);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
@@ -37,12 +37,7 @@ public class BoothReviewService {
     public void registerBoothReview(Long userId, BoothReviewRegisterRequest request){
         User user = userService.getUserOrException(userId);
         Booth booth = boothService.getBoothOrException(request.booth_id());
-        if(!booth.getStatus().equals(BoothStatus.APPROVE)){
-            throw new OpenBookException(ErrorCode.BOOTH_NOT_APPROVED);
-        }
-        if(booth.getLinkedEvent().getOpenDate().isAfter(LocalDate.now())){
-            throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
-        }
+        checkReviewable(booth, userId);
         boothReviewRepository.save(BoothReview.builder()
                 .reviewer(user)
                 .linkedBooth(booth)
@@ -75,6 +70,18 @@ public class BoothReviewService {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         boothReviewRepository.deleteById(reviewId);
+    }
+
+    private void checkReviewable(Booth booth, long reviewerId) {
+        if(!booth.getStatus().equals(BoothStatus.APPROVE)){
+            throw new OpenBookException(ErrorCode.BOOTH_NOT_APPROVED);
+        }
+        if(booth.getLinkedEvent().getOpenDate().isAfter(LocalDate.now())){
+            throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
+        }
+        if(boothReviewRepository.existsByReviewerIdAndLinkedBoothId(reviewerId, booth.getId())) {
+            throw new OpenBookException(ErrorCode.ALREADY_REVIEW);
+        }
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -95,7 +95,7 @@ public class EventReviewService {
             throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
         }
         if(eventReviewRepository.existsByReviewerIdAndLinkedEventId(reviewerId, event.getId())) {
-            throw new OpenBookException(ErrorCode.ALREADY_REVIEW);
+            throw new OpenBookException(ErrorCode.ALREADY_EXIST_REVIEW);
         }
     }
 

--- a/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventReviewService.java
@@ -51,12 +51,7 @@ public class EventReviewService {
     public void registerEventReview(Long loginUser, EventReviewRegisterRequest request) {
         User user = userService.getUserOrException(loginUser);
         Event event = eventService.getEventOrException(request.event_id());
-        if(!event.getStatus().equals(EventStatus.APPROVE)) {
-            throw new OpenBookException(ErrorCode.EVENT_NOT_APPROVED);
-        }
-        if(event.getOpenDate().isAfter(LocalDate.now())) {
-            throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
-        }
+        checkReviewable(event, loginUser);
         EventReview review = eventReviewRepository.save(EventReview.builder()
                 .reviewer(user)
                 .linkedEvent(event)
@@ -90,6 +85,18 @@ public class EventReviewService {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
         eventReviewRepository.deleteById(reviewId);
+    }
+
+    private void checkReviewable(Event event, long reviewerId) {
+        if(!event.getStatus().equals(EventStatus.APPROVE)) {
+            throw new OpenBookException(ErrorCode.EVENT_NOT_APPROVED);
+        }
+        if(event.getOpenDate().isAfter(LocalDate.now())) {
+            throw new OpenBookException(ErrorCode.CANNOT_REVIEW_PERIOD);
+        }
+        if(eventReviewRepository.existsByReviewerIdAndLinkedEventId(reviewerId, event.getId())) {
+            throw new OpenBookException(ErrorCode.ALREADY_REVIEW);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #233 

리뷰 생성 요청 시, 이미 해당 행사 또는 부스에 대해 작성한 리뷰가 있는 경우 오류를 반환하도록 수정했습니다.
409 오류를 반환합니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 이미 작성한 리뷰가 있는 경우의 오류 코드 추가
- 행사/부스 repository 에 exists 쿼리 메서드 추가
- 기존 행사/부스 서비스의 유효성 검증 로직을 checkReviewable 로 분리

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**이미 등록한 리뷰가 있는 행사나 부스에 리뷰 등록을 시도할 경우**
![image](https://github.com/user-attachments/assets/ce6c6c04-f3cd-4c50-93f1-306f111842f9)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 에러 코드를 고민하다가 일단 ALREADY_REVIEW 로 하긴 했는데, 혹시 좋은 아이디어 있으시면 말씀해주세요!!
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃