### PR TITLE
Feat: 행사 공지사항 수정 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/event/EventNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/event/EventNoticeController.java
@@ -1,12 +1,14 @@
 package com.openbook.openbook.api.event;
 
 
+import com.openbook.openbook.api.event.request.EventNoticeModifyRequest;
 import com.openbook.openbook.api.event.request.EventNoticeRegisterRequest;
 import com.openbook.openbook.api.event.response.EventNoticeResponse;
 import com.openbook.openbook.service.event.EventNoticeService;
 import com.openbook.openbook.api.ResponseMessage;
 import com.openbook.openbook.api.SliceResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -15,8 +17,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,6 +47,15 @@ public class EventNoticeController {
                                                       @Valid EventNoticeRegisterRequest request) {
         eventNoticeService.registerEventNotice(Long.valueOf(authentication.getName()), event_id, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/event/notices/{notice_id}")
+    public ResponseMessage modifyNotice(Authentication authentication,
+                                        @PathVariable Long notice_id,
+                                        @NotNull EventNoticeModifyRequest request) {
+        eventNoticeService.updateNotice(Long.parseLong(authentication.getName()), notice_id, request);
+        return new ResponseMessage("공지 수정에 성공했습니다.");
     }
 
     @DeleteMapping("/events/notices/{notice_id}")

--- a/src/main/java/com/openbook/openbook/api/event/request/EventNoticeModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/event/request/EventNoticeModifyRequest.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.api.event.request;
+
+import com.openbook.openbook.domain.event.dto.EventNoticeType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import org.springframework.web.multipart.MultipartFile;
+
+public record EventNoticeModifyRequest(
+        String title,
+        String content,
+        @Enumerated(EnumType.STRING)
+        EventNoticeType noticeType,
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/openbook/openbook/domain/event/EventNotice.java
+++ b/src/main/java/com/openbook/openbook/domain/event/EventNotice.java
@@ -3,6 +3,7 @@ package com.openbook.openbook.domain.event;
 
 import com.openbook.openbook.domain.event.dto.EventNoticeType;
 import com.openbook.openbook.domain.EntityBasicTime;
+import com.openbook.openbook.service.event.dto.EventNoticeUpdateData;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -44,4 +45,20 @@ public class EventNotice extends EntityBasicTime {
         this.imageUrl = imageUrl;
         this.linkedEvent = linkedEvent;
     }
+
+    public void updateNotice(EventNoticeUpdateData updateData) {
+        if(updateData.title()!=null) {
+            this.title = updateData.title();
+        }
+        if(updateData.content()!=null) {
+            this.content = updateData.content();
+        }
+        if (updateData.type()!=null) {
+            this.type = updateData.type().name();
+        }
+        if (updateData.imageUrl()!=null) {
+            this.imageUrl = updateData.imageUrl();
+        }
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/service/event/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventNoticeService.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.service.event;
 
 
+import com.openbook.openbook.api.event.request.EventNoticeModifyRequest;
 import com.openbook.openbook.api.event.request.EventNoticeRegisterRequest;
 import com.openbook.openbook.service.event.dto.EventNoticeDto;
 import com.openbook.openbook.domain.event.Event;
@@ -8,6 +9,7 @@ import com.openbook.openbook.domain.event.EventNotice;
 import com.openbook.openbook.repository.event.EventNoticeRepository;
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
+import com.openbook.openbook.service.event.dto.EventNoticeUpdateData;
 import com.openbook.openbook.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -53,6 +55,21 @@ public class EventNoticeService {
                 .imageUrl(s3Service.uploadFileAndGetUrl(request.image()))
                 .linkedEvent(event)
                 .build()
+        );
+    }
+
+    @Transactional
+    public void updateNotice(long userId, long noticeId, EventNoticeModifyRequest request) {
+        EventNotice notice = getEventNoticeOrException(noticeId);
+        if(!notice.getLinkedEvent().getManager().getId().equals(userId)) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        notice.updateNotice(EventNoticeUpdateData.builder()
+                        .title(request.title())
+                        .content(request.content())
+                        .type(request.noticeType())
+                        .imageUrl((request.image()!=null)?s3Service.uploadFileAndGetUrl(request.image()):null)
+                        .build()
         );
     }
 

--- a/src/main/java/com/openbook/openbook/service/event/dto/EventNoticeUpdateData.java
+++ b/src/main/java/com/openbook/openbook/service/event/dto/EventNoticeUpdateData.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.service.event.dto;
+
+import com.openbook.openbook.domain.event.dto.EventNoticeType;
+import lombok.Builder;
+
+@Builder
+public record EventNoticeUpdateData(
+        String title,
+        String content,
+        EventNoticeType type,
+        String imageUrl
+) {
+
+}
+


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #246 

행사의 공지사항을 수정하는 API 를 개발했습니다.

API
- PATCH
- /event/notices/{notice_id}

body
- title
- content
- noticeType
- image

수정하고 싶은 값만 포함시켜서 전달시키면 됩니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 요청 객체, 엔티티로 값을 전달할 dto 객체를 생성했습니다.
- 행사 공지 엔티티 안에 update 메서드를 추가했습니다.


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
기존 공지 데이터

![image](https://github.com/user-attachments/assets/420a5121-9696-4956-bb5e-85fecb075a0b)

**[성공할 경우]**
- 요청
![image](https://github.com/user-attachments/assets/e8cf34d1-3ef6-4235-8793-86096315398b)
- 응답
![image](https://github.com/user-attachments/assets/e5e8584b-3ae9-4524-8af3-639ff064e147)
- 변경 확인
![image](https://github.com/user-attachments/assets/46deaf23-10fa-45fb-b679-89d41b04c8c3)

**[로그인한 유저가 행사 관리자가 아닌 경우]**
- 403 에러
![image](https://github.com/user-attachments/assets/66357e01-6187-41d7-bfee-a576eb4ce4f7)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 공지 등, 수정 기능이 포함된 엔티티의 경우 수정 시간 필드도 추가하는 것이 좋을까요?
- 궁금하신 점, 개선할 점 등 의견 편하게 주세요! 