### PR TITLE
Feat: 부스 수정 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothController.java
@@ -12,6 +12,7 @@ import com.openbook.openbook.api.PageResponse;
 import com.openbook.openbook.api.ResponseMessage;
 import com.openbook.openbook.api.SliceResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -95,7 +96,7 @@ public class BoothController {
     @PatchMapping("/booths/{booth_id}")
     public ResponseMessage modifyReview(Authentication authentication,
                                         @PathVariable Long booth_id,
-                                        @Valid BoothModifyRequest request){
+                                        @NotNull BoothModifyRequest request){
         boothService.modifyBooth(Long.parseLong(authentication.getName()), booth_id, request);
         return new ResponseMessage("부스 수정에 성공했습니다.");
     }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothController.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.api.booth;
 
 
+import com.openbook.openbook.api.booth.request.BoothModifyRequest;
 import com.openbook.openbook.api.booth.request.BoothRegistrationRequest;
 import com.openbook.openbook.api.booth.request.BoothStatusUpdateRequest;
 import com.openbook.openbook.api.booth.response.BoothBasicData;
@@ -24,7 +25,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -87,6 +89,15 @@ public class BoothController {
         return SliceResponse.of(
                 boothService.getBoothsByManager(Long.valueOf(authentication.getName()), pageable, status)
                         .map(BoothManageData::of));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/booths/{booth_id}")
+    public ResponseMessage modifyReview(Authentication authentication,
+                                        @PathVariable Long booth_id,
+                                        @Valid BoothModifyRequest request){
+        boothService.modifyBooth(Long.parseLong(authentication.getName()), booth_id, request);
+        return new ResponseMessage("부스 수정에 성공했습니다.");
     }
 
     @DeleteMapping("/booths/{boothId}")

--- a/src/main/java/com/openbook/openbook/api/booth/request/BoothModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/BoothModifyRequest.java
@@ -1,0 +1,20 @@
+package com.openbook.openbook.api.booth.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record BoothModifyRequest(
+        @NotBlank String name,
+        @NotBlank String description,
+        @NotNull String openTime,
+        @NotNull String closeTime,
+        @NotNull MultipartFile mainImage,
+        List<String> tagToAdd,
+        List<Long> tagToDelete,
+        String accountBankName,
+        String accountNumber
+        ) {
+}

--- a/src/main/java/com/openbook/openbook/api/booth/request/BoothModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/BoothModifyRequest.java
@@ -7,11 +7,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public record BoothModifyRequest(
-        @NotBlank String name,
-        @NotBlank String description,
-        @NotNull String openTime,
-        @NotNull String closeTime,
-        @NotNull MultipartFile mainImage,
+        String name,
+        String description,
+        String openTime,
+        String closeTime,
+        MultipartFile mainImage,
         List<String> tagToAdd,
         List<Long> tagToDelete,
         String accountBankName,

--- a/src/main/java/com/openbook/openbook/domain/booth/Booth.java
+++ b/src/main/java/com/openbook/openbook/domain/booth/Booth.java
@@ -77,6 +77,17 @@ public class Booth extends EntityBasicTime {
 
     public void updateStatus(BoothStatus status){ this.status = status; }
 
+    public void updateBooth(String name, String description, String mainImageUrl,
+                            String accountNumber, String accountBankName, LocalDateTime openTime, LocalDateTime closeTime){
+        this.name = name;
+        this.description = description;
+        this.mainImageUrl = mainImageUrl;
+        this.accountNumber = accountNumber;
+        this.accountBankName = accountBankName;
+        this.openTime = openTime;
+        this.closeTime = closeTime;
+    }
+
     @Builder
     public Booth(User manager, Event linkedEvent, String name, String description, String mainImageUrl,
                  String accountBankName, String accountNumber, LocalDateTime openTime, LocalDateTime closeTime) {

--- a/src/main/java/com/openbook/openbook/domain/booth/Booth.java
+++ b/src/main/java/com/openbook/openbook/domain/booth/Booth.java
@@ -4,6 +4,7 @@ import com.openbook.openbook.domain.booth.dto.BoothStatus;
 import com.openbook.openbook.domain.event.Event;
 import com.openbook.openbook.domain.EntityBasicTime;
 import com.openbook.openbook.domain.user.User;
+import com.openbook.openbook.service.booth.dto.BoothUpdateData;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -77,15 +78,29 @@ public class Booth extends EntityBasicTime {
 
     public void updateStatus(BoothStatus status){ this.status = status; }
 
-    public void updateBooth(String name, String description, String mainImageUrl,
-                            String accountNumber, String accountBankName, LocalDateTime openTime, LocalDateTime closeTime){
-        this.name = name;
-        this.description = description;
-        this.mainImageUrl = mainImageUrl;
-        this.accountNumber = accountNumber;
-        this.accountBankName = accountBankName;
-        this.openTime = openTime;
-        this.closeTime = closeTime;
+    public void updateBooth(BoothUpdateData updateData){
+        if(updateData.name() != null){
+            this.name = updateData.name();
+        }
+        if(updateData.description() != null){
+            this.description = updateData.description();
+        }
+        if(updateData.openTime() != null){
+            this.openTime = updateData.openTime();
+        }
+        if(updateData.closeTime() != null){
+            this.closeTime = updateData.closeTime();
+        }
+        if(updateData.mainImage() != null){
+            this.mainImageUrl = updateData.mainImage();
+        }
+        if(updateData.accountBankName() != null){
+            this.accountBankName = updateData.accountBankName();
+        }
+        if(updateData.accountNumber() != null){
+            this.accountNumber = updateData.accountNumber();
+        }
+
     }
 
     @Builder

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     INVALID_RESERVED_DATE(HttpStatus.CONFLICT, "예약 날짜가 유효하지 않습니다."),
     EMPTY_TAG_DATA(HttpStatus.CONFLICT, "공백을 태그로 사용할 수 없습니다."),
     ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
+    EXCEED_MAXIMUM_TAG(HttpStatus.CONFLICT, "등록할 수 있는 최대 태그 수를 초과했습니다."),
     EVENT_NOT_APPROVED(HttpStatus.CONFLICT, "승인되지 않은 행사입니다."),
     BOOTH_NOT_APPROVED(HttpStatus.CONFLICT, "승인되지 않은 부스입니다."),
     UNAVAILABLE_RESERVED_TIME(HttpStatus.CONFLICT, "예약 가능 시간이 아닙니다."),
@@ -42,6 +43,7 @@ public enum ErrorCode {
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
     ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 시간 입니다."),
     ALREADY_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크 목록에 존재합니다."),
+
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),
 
@@ -53,6 +55,7 @@ public enum ErrorCode {
     BOOTH_NOT_FOUND(HttpStatus.NOT_FOUND, "부스 정보를 찾을 수 없습니다."),
     PRODUCT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 카테고리를 찾을 수 없습니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그 정보를 찾을 수 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "구역 정보를 찾을 수 없습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰 정보를 찾을 수 없습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알림 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothTagRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothTagRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +19,8 @@ public interface BoothTagRepository extends JpaRepository<BoothTag, Long> {
 
     @Query("SELECT distinct bt.linkedBooth FROM BoothTag bt WHERE bt.name LIKE %:name% AND bt.linkedBooth.status=:boothStatus")
     Slice<Booth> findAllBoothByName(Pageable pageable, String name, BoothStatus boothStatus);
+
+    @Modifying
+    @Query("DELETE FROM BoothTag bt WHERE bt.id = :id")
+    void deleteById(Long id);
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothService.java
@@ -11,6 +11,7 @@ import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.repository.booth.BoothRepository;
 import com.openbook.openbook.service.booth.dto.BoothDto;
 import com.openbook.openbook.domain.event.Event;
+import com.openbook.openbook.service.booth.dto.BoothUpdateData;
 import com.openbook.openbook.service.event.EventService;
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
@@ -142,8 +143,16 @@ public class BoothService {
         LocalDateTime close = getDateTime(event.getCloseDate() + " " + request.closeTime());
         dateTimePeriodCheck(open, close, event);
 
-        booth.updateBooth(request.name(), request.description(), s3Service.uploadFileAndGetUrl(request.mainImage()),
-                request.accountNumber(), request.accountBankName(), open, close);
+        booth.updateBooth(BoothUpdateData.builder()
+                .name(request.name())
+                .description(request.description())
+                .openTime(open)
+                .closeTime(close)
+                .mainImage(s3Service.uploadFileAndGetUrl(request.mainImage()))
+                .accountBankName(request.accountBankName())
+                .accountNumber(request.accountNumber())
+                .build()
+        );
 
         if(request.tagToAdd() != null || request.tagToDelete() != null){
             boothTagService.modifyBoothTag(request.tagToAdd(), request.tagToDelete(), booth);

--- a/src/main/java/com/openbook/openbook/service/booth/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothTagService.java
@@ -47,11 +47,9 @@ public class BoothTagService {
     public void modifyBoothTag(List<String> tagsToAdd, List<Long> tagsToDelete, Booth booth){
         int add = (tagsToAdd != null) ? tagsToAdd.size() : 0;
         int delete = (tagsToDelete != null) ? tagsToDelete.size() : 0;
-
         if(booth.getBoothTags().size() - delete + add > 5){
             throw new OpenBookException(ErrorCode.EXCEED_MAXIMUM_TAG);
         }
-
         createBoothTags(tagsToAdd, booth);
 
         for(int i = 0; i < delete; i++){
@@ -59,7 +57,6 @@ public class BoothTagService {
             if(tag.getLinkedBooth() != booth){
                 throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
             }
-
             boothTagRepository.deleteById(tag.getId());
         }
     }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothTagService.java
@@ -35,10 +35,6 @@ public class BoothTagService {
         );
     }
 
-    public List<BoothTag> getBoothTag(Long id){
-        return boothTagRepository.findAllByLinkedBoothId(id);
-    }
-
     public Slice<Booth> getBoothByTag(Pageable pageable, String boothTag, BoothStatus status){
         return boothTagRepository.findAllBoothByName(pageable, boothTag, status);
     }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothTagService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothTagService.java
@@ -3,6 +3,8 @@ package com.openbook.openbook.service.booth;
 import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.domain.booth.BoothTag;
 import com.openbook.openbook.domain.booth.dto.BoothStatus;
+import com.openbook.openbook.exception.ErrorCode;
+import com.openbook.openbook.exception.OpenBookException;
 import com.openbook.openbook.repository.booth.BoothTagRepository;
 import com.openbook.openbook.util.TagUtil;
 import java.util.List;
@@ -10,11 +12,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BoothTagService {
     private final BoothTagRepository boothTagRepository;
+
+    public BoothTag getBoothTagOrException(long boothTagId){
+        return boothTagRepository.findById(boothTagId).orElseThrow(
+                () -> new OpenBookException(ErrorCode.TAG_NOT_FOUND)
+        );
+    }
 
     public void createBoothTags(List<String> names, Booth booth) {
         TagUtil.getValidTagsOrException(names).forEach(
@@ -32,5 +41,26 @@ public class BoothTagService {
 
     public Slice<Booth> getBoothByTag(Pageable pageable, String boothTag, BoothStatus status){
         return boothTagRepository.findAllBoothByName(pageable, boothTag, status);
+    }
+
+    @Transactional
+    public void modifyBoothTag(List<String> tagsToAdd, List<Long> tagsToDelete, Booth booth){
+        int add = (tagsToAdd != null) ? tagsToAdd.size() : 0;
+        int delete = (tagsToDelete != null) ? tagsToDelete.size() : 0;
+
+        if(booth.getBoothTags().size() - delete + add > 5){
+            throw new OpenBookException(ErrorCode.EXCEED_MAXIMUM_TAG);
+        }
+
+        createBoothTags(tagsToAdd, booth);
+
+        for(int i = 0; i < delete; i++){
+            BoothTag tag = getBoothTagOrException(tagsToDelete.get(i));
+            if(tag.getLinkedBooth() != booth){
+                throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+            }
+
+            boothTagRepository.deleteById(tag.getId());
+        }
     }
 }

--- a/src/main/java/com/openbook/openbook/service/booth/dto/BoothUpdateData.java
+++ b/src/main/java/com/openbook/openbook/service/booth/dto/BoothUpdateData.java
@@ -1,0 +1,17 @@
+package com.openbook.openbook.service.booth.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record BoothUpdateData(
+        String name,
+        String description,
+        LocalDateTime openTime,
+        LocalDateTime closeTime,
+        String mainImage,
+        String accountBankName,
+        String accountNumber
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #238 
PATCH /booths/{booth_id}

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 수정할 데이터를 담을 request 클래스를 추가했습니다.
- 앞서 행사 리뷰 수정과 유사하게 추가할 태그 tagToAdd와 tagToDelete 필드를 만들었고, 이를 통해 최대 개수(5) 를 넘는지 판별하게 됩니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/5d1fa0fb-4afc-43e1-a683-3fbb017c3e79">

- 최대 개수를 넘는 경우
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/e10a9cc1-b8d7-439f-b1b2-10b38df7005c">

- 삭제하려는 태그 데이터가 해당 부스의 태그 데이터가 아닐 경우
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/cfa0e704-88d0-49b5-95f6-b3d65e1092b5">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 태그 데이터를 일부 삭제하고 싶을 경우 원래는 jpa에서 기본으로 제공해주는 delete 메소드를 사용했었는데, 데이터가 제거되지 않고 update문이 나가는 문제가 발생했었습니다. 알아보니 정확한 이유는 아니지만 영속성의 문제라고 보이는데 지금 생각한 방안으로는 delete 쿼리문을 직접 만들어서 사용하는 방법으로 우선 개발했습니다. 혹시 다른 좋은 방법 생각나시면 말씀해주세요 !
- 저번 공지 수정건을 보니 dto를 따로 하나 만들어서 구현하셨던데 이번에도 그런 방향으로 할 지 의견 부탁드립니다!
- 다른 의견이나 질문 있으시면 리뷰 남겨주세요! 😊