### PR TITLE
Feat: 부스 상품 카테고리 삭제 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
@@ -56,6 +56,7 @@ public class BoothProductController {
     public ResponseMessage deleteProductCategory(Authentication authentication,
                                                  @PathVariable Long category_id,
                                                  @RequestParam(defaultValue = "false") String deleteProducts) {
+        boothProductService.deleteCategory(Long.parseLong(authentication.getName()), category_id, deleteProducts);
         return new ResponseMessage("상품 카테고리 삭제에 성공했습니다.");
     }
 

--- a/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
@@ -51,6 +51,14 @@ public class BoothProductController {
         return new ResponseMessage("상품 삭제에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/booths/product-categories/{category_id}")
+    public ResponseMessage deleteProductCategory(Authentication authentication,
+                                                 @PathVariable Long category_id,
+                                                 @RequestParam(defaultValue = "false") String deleteProducts) {
+        return new ResponseMessage("상품 카테고리 삭제에 성공했습니다.");
+    }
+
     @GetMapping("/booths/{booth_id}/product-category")
     public ResponseEntity<List<ProductCategoryResponse>> getProductCategory(@PathVariable Long booth_id) {
         return ResponseEntity.ok(boothProductService.getProductCategoryResponseList(booth_id));

--- a/src/main/java/com/openbook/openbook/domain/booth/BoothProduct.java
+++ b/src/main/java/com/openbook/openbook/domain/booth/BoothProduct.java
@@ -40,4 +40,8 @@ public class BoothProduct {
         this.linkedCategory = linkedCategory;
     }
 
+    public void updateCategory(BoothProductCategory category) {
+        this.linkedCategory = category;
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/domain/booth/BoothProductCategory.java
+++ b/src/main/java/com/openbook/openbook/domain/booth/BoothProductCategory.java
@@ -1,16 +1,12 @@
 package com.openbook.openbook.domain.booth;
 
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,9 +26,6 @@ public class BoothProductCategory {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Booth linkedBooth;
-
-    @OneToMany(mappedBy = "linkedCategory", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<BoothProduct> boothProducts = new ArrayList<>();
 
     @Builder
     public BoothProductCategory(String name, String description, Booth linkedBooth) {

--- a/src/main/java/com/openbook/openbook/exception/ErrorCode.java
+++ b/src/main/java/com/openbook/openbook/exception/ErrorCode.java
@@ -33,18 +33,23 @@ public enum ErrorCode {
     INVALID_DATE_RANGE(HttpStatus.CONFLICT, "입력된 날짜 범위가 유효하지 않습니다."),
     INVALID_LAYOUT_ENTRY(HttpStatus.CONFLICT, "입력된 배치도 형식에 오류가 있습니다."),
     INVALID_RESERVED_DATE(HttpStatus.CONFLICT, "예약 날짜가 유효하지 않습니다."),
+
     EMPTY_TAG_DATA(HttpStatus.CONFLICT, "공백을 태그로 사용할 수 없습니다."),
     ALREADY_TAG_DATA(HttpStatus.CONFLICT, "중복 되는 태그 데이터가 있습니다."),
     EXCEED_MAXIMUM_TAG(HttpStatus.CONFLICT, "등록할 수 있는 최대 태그 수를 초과했습니다."),
+
     EVENT_NOT_APPROVED(HttpStatus.CONFLICT, "승인되지 않은 행사입니다."),
     BOOTH_NOT_APPROVED(HttpStatus.CONFLICT, "승인되지 않은 부스입니다."),
+
     UNAVAILABLE_RESERVED_TIME(HttpStatus.CONFLICT, "예약 가능 시간이 아닙니다."),
     ALREADY_RESERVED_DATE(HttpStatus.CONFLICT, "이미 존재하는 예약 날짜 입니다."),
     DUPLICATE_RESERVED_TIME(HttpStatus.CONFLICT, "중복 되는 시간 데이터가 있습니다."),
     ALREADY_RESERVED_SERVICE(HttpStatus.CONFLICT, "이미 예약된 시간 입니다."),
+
     ALREADY_BOOKMARK(HttpStatus.CONFLICT, "이미 북마크 목록에 존재합니다."),
 
     EXCEED_MAXIMUM_CATEGORY(HttpStatus.CONFLICT, "생성할 수 있는 최대 카테고리 수를 초과했습니다."),
+    DEFAULT_CATEGORY_CANNOT_DELETED(HttpStatus.CONFLICT, "기본 카테고리는 삭제할 수 없습니다."),
     ALREADY_EXIST_CATEGORY(HttpStatus.CONFLICT, "이미 존재하는 카테고리 입니다."),
 
     // NOT FOUND

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothProductCategoryRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothProductCategoryRepository.java
@@ -13,6 +13,8 @@ public interface BoothProductCategoryRepository extends JpaRepository<BoothProdu
 
     boolean existsByLinkedBoothIdAndName(Long linkedBoothId, String name);
 
+    BoothProductCategory findByLinkedBoothIdAndName(Long linkedBoothId, String name);
+
     List<BoothProductCategory> findAllByLinkedBoothId(Long linkedBoothId);
 
 }

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothProductRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothProductRepository.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.repository.booth;
 
 import com.openbook.openbook.domain.booth.BoothProduct;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,5 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface BoothProductRepository extends JpaRepository<BoothProduct, Long> {
 
     Slice<BoothProduct> findAllByLinkedCategoryId(Long linkedCategoryId, Pageable pageable);
+
+    List<BoothProduct> findAllByLinkedCategoryId(Long linkedCategoryId);
 
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductCategoryService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductCategoryService.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.service.booth;
 
 
 import com.openbook.openbook.domain.booth.Booth;
+import com.openbook.openbook.domain.booth.BoothProduct;
 import com.openbook.openbook.domain.booth.BoothProductCategory;
 import com.openbook.openbook.repository.booth.BoothProductCategoryRepository;
 import com.openbook.openbook.exception.ErrorCode;
@@ -15,12 +16,17 @@ import org.springframework.stereotype.Service;
 public class BoothProductCategoryService {
 
     private final BoothProductCategoryRepository categoryRepository;
+    private final String DEFAULT_NAME = "기본";
 
 
     public BoothProductCategory getProductCategoryOrException(final long id) {
         return categoryRepository.findById(id).orElseThrow(()->
                 new OpenBookException(ErrorCode.PRODUCT_CATEGORY_NOT_FOUND)
         );
+    }
+
+    public BoothProductCategory getDefaultCategory(Booth linkedBooth) {
+        return categoryRepository.findByLinkedBoothIdAndName(linkedBooth.getId(), DEFAULT_NAME);
     }
 
     public boolean isExistsCategoryIn(Booth linkedBooth, String name) {

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductCategoryService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductCategoryService.java
@@ -25,6 +25,16 @@ public class BoothProductCategoryService {
         );
     }
 
+    public void createProductCategory(String categoryName, String description, Booth linkedBooth) {
+        categoryRepository.save(
+                BoothProductCategory.builder()
+                        .name(categoryName)
+                        .description(description)
+                        .linkedBooth(linkedBooth)
+                        .build()
+        );
+    }
+
     public void deleteProductCategory(final BoothProductCategory category) {
         if(category.getName().equals(DEFAULT_NAME)) {
             throw new OpenBookException(ErrorCode.DEFAULT_CATEGORY_CANNOT_DELETED);
@@ -48,13 +58,5 @@ public class BoothProductCategoryService {
         return categoryRepository.findAllByLinkedBoothId(linkedBooth.getId());
     }
 
-    public void createProductCategory(String categoryName, String description, Booth linkedBooth) {
-        categoryRepository.save(
-                BoothProductCategory.builder()
-                        .name(categoryName)
-                        .description(description)
-                        .linkedBooth(linkedBooth)
-                        .build()
-        );
-    }
+
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductCategoryService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductCategoryService.java
@@ -25,6 +25,13 @@ public class BoothProductCategoryService {
         );
     }
 
+    public void deleteProductCategory(final BoothProductCategory category) {
+        if(category.getName().equals(DEFAULT_NAME)) {
+            throw new OpenBookException(ErrorCode.DEFAULT_CATEGORY_CANNOT_DELETED);
+        }
+        categoryRepository.deleteById(category.getId());
+    }
+
     public BoothProductCategory getDefaultCategory(Booth linkedBooth) {
         return categoryRepository.findByLinkedBoothIdAndName(linkedBooth.getId(), DEFAULT_NAME);
     }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
@@ -127,8 +127,6 @@ public class BoothProductService {
         if(category.getLinkedBooth().getManager().getId()!=userId) {
             throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
         }
-        categoryService.deleteProductCategory(category);
-
         BoothProductCategory defaultCategory = categoryService.getDefaultCategory(category.getLinkedBooth());
         boolean delete = deleteProduct.equals("true");
         boothProductRepository.findAllByLinkedCategoryId(categoryId).forEach(product -> {
@@ -139,6 +137,7 @@ public class BoothProductService {
                 product.updateCategory(defaultCategory);
             }
         });
+        categoryService.deleteProductCategory(category);
     }
 
     public Slice<BoothProduct> getProductsByCategory(final BoothProductCategory category, final Pageable pageable) {

--- a/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothProductService.java
@@ -121,6 +121,26 @@ public class BoothProductService {
         boothProductRepository.delete(product);
     }
 
+    @Transactional
+    public void deleteCategory(final long userId, final long categoryId, final String deleteProduct) {
+        BoothProductCategory category = categoryService.getProductCategoryOrException(categoryId);
+        if(category.getLinkedBooth().getManager().getId()!=userId) {
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        categoryService.deleteProductCategory(category);
+
+        BoothProductCategory defaultCategory = categoryService.getDefaultCategory(category.getLinkedBooth());
+        boolean delete = deleteProduct.equals("true");
+        boothProductRepository.findAllByLinkedCategoryId(categoryId).forEach(product -> {
+            if(delete) {
+                boothProductRepository.delete(product);
+            }
+            else {
+                product.updateCategory(defaultCategory);
+            }
+        });
+    }
+
     public Slice<BoothProduct> getProductsByCategory(final BoothProductCategory category, final Pageable pageable) {
         return boothProductRepository.findAllByLinkedCategoryId(category.getId(), pageable);
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #255 

부스 상품 카테고리를 삭제하는 API 를 개발했습니다.
- 기본 카테고리는 삭제할 수 없습니다.
- 삭제하는 카테고리의 하위 상품을 삭제하지 않을 경우 자동으로 기본 카테고리로 들어가게 됩니다.

API
- DELETE
- /booths/product-categories/{category_id}

Param
- deleteProducts (true/false)
: 카테고리의 하위에 있는 상품들의 삭제 여부를 보냅니다.


## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- ErrorCode: 기본 카테고리를 삭제하려는 경우의 오류 코드 추가 
- BoothProduct(Entity): 카테고리 업데이트 메서드 추가
- BoothProductCategory: 일대다 연관관계 삭제


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

**성공** (안의 상품은 기본 카테고리로 이동)
- DELETE {{local}}/booths/product-categories/44?deleteProducts=false
![image](https://github.com/user-attachments/assets/299420f0-f45f-4acd-a73a-3b11edd917ba)

**성공** (안의 상품까지 삭제)
- DELETE {{local}}/booths/product-categories/47?deleteProducts=true
![image](https://github.com/user-attachments/assets/006b4d60-e72e-4a25-86ef-72d02c27b1c6)

**실패** (기본 카테고리인 경우)
- DELETE {{local}}/booths/product-categories/36
![image](https://github.com/user-attachments/assets/56a870e1-c637-48f2-9068-746220ead94c)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선 방안 등 편하게 의견 주세요! 😃