### PR TITLE
Feat: 부스 공지 수정 API

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,7 +65,7 @@ jobs:
         script: |
           sudo docker ps
           sudo docker pull ${{ secrets.DOCKER_USERNAME }}/openbook
-          sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/openbook
+          sudo docker run -d -p 8081:8080 ${{ secrets.DOCKER_USERNAME }}/openbook
           sudo docker image prune -f
 
 

--- a/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
@@ -1,12 +1,14 @@
 package com.openbook.openbook.api.booth;
 
 
+import com.openbook.openbook.api.booth.request.BoothNoticeModifyRequest;
 import com.openbook.openbook.api.booth.request.BoothNoticeRegisterRequest;
 import com.openbook.openbook.api.booth.response.BoothNoticeResponse;
 import com.openbook.openbook.service.booth.BoothNoticeService;
 import com.openbook.openbook.api.ResponseMessage;
 import com.openbook.openbook.api.SliceResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -14,8 +16,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -40,6 +44,15 @@ public class BoothNoticeController {
     @GetMapping("/booths/notices/{noticeId}")
     public ResponseEntity<BoothNoticeResponse> getBoothNotice(@PathVariable Long noticeId){
         return ResponseEntity.ok(BoothNoticeResponse.of(boothNoticeService.getBoothNotice(noticeId)));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/booths/notices/{notice_id}")
+    public ResponseMessage modifyNotice(Authentication authentication,
+                                        @PathVariable Long notice_id,
+                                        @NotNull BoothNoticeModifyRequest request){
+        boothNoticeService.modifyNotice(Long.parseLong(authentication.getName()), notice_id, request);
+        return new ResponseMessage("공지 수정에 성공했습니다.");
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/booth/request/BoothNoticeModifyRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/BoothNoticeModifyRequest.java
@@ -1,0 +1,15 @@
+package com.openbook.openbook.api.booth.request;
+
+import com.openbook.openbook.domain.booth.dto.BoothNoticeType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import org.springframework.web.multipart.MultipartFile;
+
+public record BoothNoticeModifyRequest(
+        String title,
+        String content,
+        @Enumerated(EnumType.STRING)
+        BoothNoticeType noticeType,
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/openbook/openbook/domain/booth/BoothNotice.java
+++ b/src/main/java/com/openbook/openbook/domain/booth/BoothNotice.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.domain.booth;
 
 import com.openbook.openbook.domain.booth.dto.BoothNoticeType;
 import com.openbook.openbook.domain.EntityBasicTime;
+import com.openbook.openbook.service.booth.dto.BoothNoticeUpdateData;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -36,5 +37,20 @@ public class BoothNotice extends EntityBasicTime {
         this.type = type.name();
         this.imageUrl = imageUrl;
         this.linkedBooth = linkedBooth;
+    }
+
+    public void updateNotice(BoothNoticeUpdateData noticeUpdateData){
+        if(noticeUpdateData.title() != null){
+            this.title = noticeUpdateData.title();
+        }
+        if(noticeUpdateData.content() != null){
+            this.content = noticeUpdateData.content();
+        }
+        if(noticeUpdateData.title() != null){
+            this.type = noticeUpdateData.type().name();
+        }
+        if(noticeUpdateData.imageUrl() != null){
+            this.imageUrl = noticeUpdateData.imageUrl();
+        }
     }
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
@@ -1,5 +1,6 @@
 package com.openbook.openbook.service.booth;
 
+import com.openbook.openbook.api.booth.request.BoothNoticeModifyRequest;
 import com.openbook.openbook.api.booth.request.BoothNoticeRegisterRequest;
 import com.openbook.openbook.domain.booth.dto.BoothStatus;
 import com.openbook.openbook.domain.booth.Booth;
@@ -8,6 +9,7 @@ import com.openbook.openbook.repository.booth.BoothNoticeRepository;
 import com.openbook.openbook.service.booth.dto.BoothNoticeDto;
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
+import com.openbook.openbook.service.booth.dto.BoothNoticeUpdateData;
 import com.openbook.openbook.util.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -58,6 +60,21 @@ public class BoothNoticeService {
                         .linkedBooth(booth)
                         .build()
         );
+    }
+
+    @Transactional
+    public void modifyNotice(long userId, long noticeId, BoothNoticeModifyRequest request){
+        BoothNotice notice = getBoothNoticeOrException(noticeId);
+        if(!notice.getLinkedBooth().getManager().getId().equals(userId)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
+        notice.updateNotice(BoothNoticeUpdateData.builder()
+                        .title(request.title())
+                        .content(request.content())
+                        .type(request.noticeType())
+                        .imageUrl((request.image() != null)?s3Service.uploadFileAndGetUrl(request.image()):null)
+                        .build());
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/booth/dto/BoothNoticeUpdateData.java
+++ b/src/main/java/com/openbook/openbook/service/booth/dto/BoothNoticeUpdateData.java
@@ -1,0 +1,13 @@
+package com.openbook.openbook.service.booth.dto;
+
+import com.openbook.openbook.domain.booth.dto.BoothNoticeType;
+import lombok.Builder;
+
+@Builder
+public record BoothNoticeUpdateData(
+        String title,
+        String content,
+        BoothNoticeType type,
+        String imageUrl
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #253 
PATCH /booths/notices/{notice_id}

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 수정할 공지 내용을 담을 request 클래스를 새로 추가했습니다.
- 수정 기능을 수행할 boothNotice관련 controller, service 클래스에 메소드를 추가했습니다.
- 객체를 수정할 update 메소드를 boothNotice 엔티티에 추가했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
성공 시

📌 변경 전 데이터
<img width="902" alt="image" src="https://github.com/user-attachments/assets/e260c3f0-8357-4ed7-9d0c-44aa6ff47ab1">
📌 요청 값
<img width="949" alt="image" src="https://github.com/user-attachments/assets/070c3252-d2e2-445f-9037-834e596f57cb">
📌 변경 후 데이터
<img width="900" alt="image" src="https://github.com/user-attachments/assets/d5e09054-e888-4366-a9f3-087273490372">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 질문이나 의견 있으시면 리뷰 남겨주세요! 