### PR TITLE
Refactor: @ResponseStatus 를 사용하도록 변경

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothController.java
@@ -15,10 +15,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,74 +35,88 @@ public class BoothController {
 
     private final BoothService boothService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/booths")
-    public ResponseEntity<ResponseMessage> registration(Authentication authentication, @Valid BoothRegistrationRequest request){
+    public ResponseMessage registration(Authentication authentication,
+                                        @Valid BoothRegistrationRequest request){
         boothService.boothRegistration(Long.valueOf(authentication.getName()), request);
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(new ResponseMessage("신청 완료 되었습니다."));
-
+        return new ResponseMessage("부스 신청이 완료 되었습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booths")
-    public ResponseEntity<SliceResponse<BoothBasicData>> getBooths(@PageableDefault(size = 6) Pageable pageable){
-        return ResponseEntity.ok(SliceResponse.of(boothService.getBooths(pageable).map(BoothBasicData::of)));
+    public SliceResponse<BoothBasicData> getBooths(@PageableDefault(size = 6) Pageable pageable){
+        return SliceResponse.of(
+                boothService.getBooths(pageable)
+                        .map(BoothBasicData::of)
+        );
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booths/{boothId}")
-    public ResponseEntity<BoothDetail> getBooth(@PathVariable Long boothId){
-        return ResponseEntity.ok(BoothDetail.of(boothService.getBoothById(boothId)));
+    public BoothDetail getBoothDetail(@PathVariable Long boothId){
+        return BoothDetail.of(boothService.getBoothById(boothId));
     }
 
-
-    @GetMapping("/booths/search")
-    public ResponseEntity<SliceResponse<BoothBasicData>> searchBoothName(@RequestParam(value = "type") String searchType,
-                                                                         @RequestParam(value = "query", defaultValue = "") String query,
-                                                                         @RequestParam(value = "page", defaultValue = "0") int page,
-                                                                         @RequestParam(value = "sort", defaultValue = "desc") String sort){
-        Slice<BoothBasicData> result = boothService.searchBoothBy(searchType, query, page, sort).map(BoothBasicData::of);
-        return ResponseEntity.ok(SliceResponse.of(result));
-    }
-
-    @GetMapping("/events/{eventId}/managed/booths")
-    public PageResponse<BoothManageData> getBoothManagePage(@RequestParam(defaultValue = "all") String status,
-                                                                            @PathVariable Long eventId,
-                                                                            @PageableDefault(size = 10) Pageable pageable,
-                                                                            Authentication authentication){
-        return PageResponse.of(
-                boothService.getBoothsOfEvent(status, eventId, pageable, Long.valueOf(authentication.getName()))
-                        .map(BoothManageData::of));
-    }
-
-    @PutMapping("/events/booths/{boothId}/status")
-    public ResponseEntity<ResponseMessage> changeBoothStatus(@PathVariable Long boothId,
-                                                             @RequestBody BoothStatusUpdateRequest request, Authentication authentication) {
-        boothService.changeBoothStatus(boothId, request.boothStatus(), Long.valueOf(authentication.getName()));
-        return ResponseEntity.ok(new ResponseMessage("부스 상태가 변경되었습니다."));
-    }
-
-    @GetMapping("manage/booths")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/manage/booths")
     public SliceResponse<BoothManageData> getManagedBooth(Authentication authentication,
-                                                                          @PageableDefault(size = 6)Pageable pageable,
-                                                                          @RequestParam(defaultValue = "ALL") String status){
+                                                          @PageableDefault(size = 6)Pageable pageable,
+                                                          @RequestParam(defaultValue = "ALL") String status){
         return SliceResponse.of(
                 boothService.getBoothsByManager(Long.valueOf(authentication.getName()), pageable, status)
-                        .map(BoothManageData::of));
+                .map(BoothManageData::of)
+        );
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/events/{eventId}/managed/booths")
+    public PageResponse<BoothManageData> getBoothManagePage(Authentication authentication,
+                                                            @PathVariable Long eventId,
+                                                            @RequestParam(defaultValue = "all") String status,
+                                                            @PageableDefault(size = 10) Pageable pageable){
+        return PageResponse.of(
+                boothService.getBoothsOfEvent(status, eventId, pageable, Long.valueOf(authentication.getName()))
+                        .map(BoothManageData::of)
+        );
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/booths/search")
+    public SliceResponse<BoothBasicData> searchBooth(@RequestParam(value = "type") String searchType,
+                                                     @RequestParam(value = "query", defaultValue = "") String query,
+                                                     @RequestParam(value = "page", defaultValue = "0") int page,
+                                                     @RequestParam(value = "sort", defaultValue = "desc") String sort){
+        return SliceResponse.of(
+                boothService.searchBoothBy(searchType, query, page, sort)
+                .map(BoothBasicData::of)
+        );
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping("/events/booths/{boothId}/status")
+    public ResponseMessage changeBoothStatus(Authentication authentication,
+                                             @PathVariable Long boothId,
+                                             @RequestBody BoothStatusUpdateRequest request) {
+        boothService.changeBoothStatus(boothId, request.boothStatus(), Long.valueOf(authentication.getName()));
+        return new ResponseMessage("부스 상태가 변경되었습니다.");
     }
 
     @ResponseStatus(HttpStatus.OK)
     @PatchMapping("/booths/{booth_id}")
-    public ResponseMessage modifyReview(Authentication authentication,
-                                        @PathVariable Long booth_id,
-                                        @NotNull BoothModifyRequest request){
+    public ResponseMessage modifyBooth(Authentication authentication,
+                                       @PathVariable Long booth_id,
+                                       @NotNull BoothModifyRequest request){
         boothService.modifyBooth(Long.parseLong(authentication.getName()), booth_id, request);
         return new ResponseMessage("부스 수정에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/booths/{boothId}")
-    public ResponseEntity<ResponseMessage> deleteBooth(Authentication authentication, @PathVariable Long boothId){
+    public ResponseMessage deleteBooth(Authentication authentication,
+                                       @PathVariable Long boothId){
         boothService.deleteBooth(Long.valueOf(authentication.getName()), boothId);
-        return ResponseEntity.ok(new ResponseMessage("부스를 삭제했습니다."));
+        return new ResponseMessage("부스 삭제에 성공했습니다.");
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,22 +27,29 @@ public class BoothNoticeController {
 
     private final BoothNoticeService boothNoticeService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/booths/{boothId}/notices")
-    public ResponseEntity<ResponseMessage> postNotice(Authentication authentication,
-                                                      @PathVariable Long boothId,
-                                                      @Valid BoothNoticeRegisterRequest boothNoticeRegisterRequest){
-        boothNoticeService.registerBoothNotice(Long.valueOf(authentication.getName()), boothId, boothNoticeRegisterRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
+    public ResponseMessage postNotice(Authentication authentication,
+                                      @PathVariable Long boothId,
+                                      @Valid BoothNoticeRegisterRequest request){
+        boothNoticeService.registerBoothNotice(Long.valueOf(authentication.getName()), boothId, request);
+        return new ResponseMessage("공지 등록에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booths/{boothId}/notices")
-    public SliceResponse<BoothNoticeResponse> getBoothNotices(@PathVariable Long boothId, @PageableDefault(size = 5) Pageable pageable){
-        return SliceResponse.of(boothNoticeService.getBoothNotices(boothId, pageable).map(BoothNoticeResponse::of));
+    public SliceResponse<BoothNoticeResponse> getBoothNotices(@PathVariable Long boothId,
+                                                              @PageableDefault(size = 5) Pageable pageable){
+        return SliceResponse.of(
+                boothNoticeService.getBoothNotices(boothId, pageable)
+                        .map(BoothNoticeResponse::of)
+        );
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booths/notices/{noticeId}")
-    public ResponseEntity<BoothNoticeResponse> getBoothNotice(@PathVariable Long noticeId){
-        return ResponseEntity.ok(BoothNoticeResponse.of(boothNoticeService.getBoothNotice(noticeId)));
+    public BoothNoticeResponse getBoothNotice(@PathVariable Long noticeId){
+        return BoothNoticeResponse.of(boothNoticeService.getBoothNotice(noticeId));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothProductController.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,25 +27,48 @@ public class BoothProductController {
 
     private final BoothProductService boothProductService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/booths/{booth_id}/product-category")
-    public ResponseEntity<ResponseMessage> addProductCategory(Authentication authentication,
-                                                              @PathVariable Long booth_id,
-                                                              @Valid ProductCategoryRegister request) {
+    public ResponseMessage addProductCategory(Authentication authentication,
+                                              @PathVariable Long booth_id,
+                                              @Valid ProductCategoryRegister request) {
         boothProductService.addProductCategory(Long.valueOf(authentication.getName()), booth_id, request);
-        return ResponseEntity.ok(new ResponseMessage("상품 카테고리 생성에 성공했습니다."));
+        return new ResponseMessage("상품 카테고리 생성에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/booths/{booth_id}/products")
-    public ResponseEntity<ResponseMessage> addProduct(Authentication authentication,
-                                                      @PathVariable Long booth_id,
-                                                      @Valid ProductRegistrationRequest request){
+    public ResponseMessage addProduct(Authentication authentication,
+                                      @PathVariable Long booth_id,
+                                      @Valid ProductRegistrationRequest request){
         boothProductService.addBoothProduct(Long.valueOf(authentication.getName()), booth_id, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("상품 추가에 성공했습니다."));
+        return new ResponseMessage("상품 추가에 성공했습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/booths/{booth_id}/products")
+    public List<CategoryProductsResponse> getAllBoothProducts(@PathVariable Long booth_id,
+                                                              @PageableDefault(size = 5) Pageable pageable) {
+        return boothProductService.findAllBoothProducts(booth_id, pageable);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/booths/products/category")
+    public CategoryProductsResponse getProductsByCategory(@RequestParam Long category_id,
+                                                          @PageableDefault(size = 5) Pageable pageable) {
+        return boothProductService.findCategoryProducts(category_id, pageable);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/booths/{booth_id}/product-category")
+    public List<ProductCategoryResponse> getProductCategory(@PathVariable Long booth_id) {
+        return boothProductService.getProductCategoryResponseList(booth_id);
     }
 
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/booths/products/{product_id}")
-    public ResponseMessage deleteProduct(Authentication authentication, @PathVariable Long product_id) {
+    public ResponseMessage deleteProduct(Authentication authentication,
+                                         @PathVariable Long product_id) {
         boothProductService.deleteProduct(Long.parseLong(authentication.getName()), product_id);
         return new ResponseMessage("상품 삭제에 성공했습니다.");
     }
@@ -58,23 +80,6 @@ public class BoothProductController {
                                                  @RequestParam(defaultValue = "false") String deleteProducts) {
         boothProductService.deleteCategory(Long.parseLong(authentication.getName()), category_id, deleteProducts);
         return new ResponseMessage("상품 카테고리 삭제에 성공했습니다.");
-    }
-
-    @GetMapping("/booths/{booth_id}/product-category")
-    public ResponseEntity<List<ProductCategoryResponse>> getProductCategory(@PathVariable Long booth_id) {
-        return ResponseEntity.ok(boothProductService.getProductCategoryResponseList(booth_id));
-    }
-
-    @GetMapping("/booths/{booth_id}/products")
-    public ResponseEntity<List<CategoryProductsResponse>> getAllBoothProducts(@PathVariable Long booth_id,
-                                                                              @PageableDefault(size = 5) Pageable pageable) {
-        return ResponseEntity.ok(boothProductService.findAllBoothProducts(booth_id, pageable));
-    }
-
-    @GetMapping("/booths/products/category")
-    public ResponseEntity<CategoryProductsResponse> getProductsByCategory(@RequestParam Long category_id,
-                                                                          @PageableDefault(size = 5) Pageable pageable) {
-        return ResponseEntity.ok(boothProductService.findCategoryProducts(category_id, pageable));
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReservationController.java
@@ -9,12 +9,13 @@ import com.openbook.openbook.api.ResponseMessage;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -24,37 +25,48 @@ public class BoothReservationController {
 
     private final BoothReservationService reservationService;
 
-    @PostMapping("booths/{boothId}/reservation")
-    public ResponseEntity<ResponseMessage> addReservation(Authentication authentication,
-                                                          @Valid ReserveRegistrationRequest request,
-                                                          @PathVariable Long boothId){
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/booths/{boothId}/reservation")
+    public ResponseMessage addReservation(Authentication authentication,
+                                          @PathVariable Long boothId,
+                                          @Valid ReserveRegistrationRequest request){
         reservationService.addReservation(Long.valueOf(authentication.getName()), request, boothId);
-        return ResponseEntity.ok(new ResponseMessage("예약 추가에 성공했습니다."));
+        return new ResponseMessage("예약 추가에 성공했습니다.");
     }
 
-    @GetMapping("manage/booths/{boothId}/reservations")
-    public List<BoothReserveManageResponse> getManagedReservation(Authentication authentication,
-                                                                  @PathVariable Long boothId){
-        return reservationService.getAllManageReservations(Long.valueOf(authentication.getName()), boothId)
-                .stream().map(BoothReserveManageResponse::of).toList();
-    }
-
-    @PatchMapping("/manage/booths/reserve/{detail_id}")
-    public ResponseEntity<ResponseMessage> changeReserveStatus(Authentication authentication,
-                                                               @RequestBody ReserveStatusUpdateRequest request,
-                                                               @PathVariable Long detail_id){
-        reservationService.changeReserveStatus(detail_id, request, Long.valueOf(authentication.getName()));
-        return ResponseEntity.ok(new ResponseMessage("예약 상태가 변경되었습니다."));
-    }
-
-    @PatchMapping("/booths/reserve/{detail_id}")
-    public ResponseEntity<ResponseMessage> reservation(Authentication authentication, @PathVariable Long detail_id){
-        reservationService.reserveBooth(Long.valueOf(authentication.getName()), detail_id);
-        return ResponseEntity.ok(new ResponseMessage("예약 신청이 되었습니다."));
-    }
-
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booths/{booth_id}/reservations")
     public List<BoothReserveResponse> getAllBoothReservations(@PathVariable Long booth_id){
-        return reservationService.getReservationsByBooth(booth_id).stream().map(BoothReserveResponse::of).toList();
+        return reservationService.getReservationsByBooth(booth_id).stream()
+                .map(BoothReserveResponse::of)
+                .toList();
     }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/manage/booths/{boothId}/reservations")
+    public List<BoothReserveManageResponse> getManagedReservations(Authentication authentication,
+                                                                   @PathVariable Long boothId){
+        return reservationService.getAllManageReservations(Long.valueOf(authentication.getName()), boothId)
+                .stream()
+                .map(BoothReserveManageResponse::of)
+                .toList();
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/booths/reserve/{detail_id}")
+    public ResponseMessage reservation(Authentication authentication,
+                                       @PathVariable Long detail_id){
+        reservationService.reserveBooth(Long.valueOf(authentication.getName()), detail_id);
+        return new ResponseMessage("예약 신청이 되었습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/manage/booths/reserve/{detail_id}")
+    public ResponseMessage changeReserveStatus(Authentication authentication,
+                                               @PathVariable Long detail_id,
+                                               @RequestBody ReserveStatusUpdateRequest request ){
+        reservationService.changeReserveStatus(detail_id, request, Long.valueOf(authentication.getName()));
+        return new ResponseMessage("예약 상태가 변경되었습니다.");
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothReviewController.java
@@ -5,7 +5,6 @@ import com.openbook.openbook.api.SliceResponse;
 import com.openbook.openbook.api.booth.request.BoothReviewModifyRequest;
 import com.openbook.openbook.api.booth.request.BoothReviewRegisterRequest;
 import com.openbook.openbook.api.booth.response.BoothReviewResponse;
-import com.openbook.openbook.domain.booth.Booth;
 import com.openbook.openbook.service.booth.BoothReviewService;
 import com.openbook.openbook.api.ResponseMessage;
 import jakarta.validation.Valid;
@@ -14,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,12 +22,12 @@ public class BoothReviewController {
 
     private final BoothReviewService boothReviewService;
 
-
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/booths/review")
-    public ResponseEntity<ResponseMessage> postReview(Authentication authentication,
-                                                      @Valid BoothReviewRegisterRequest request){
+    public ResponseMessage postReview(Authentication authentication,
+                                      @Valid BoothReviewRegisterRequest request){
         boothReviewService.registerBoothReview(Long.valueOf(authentication.getName()), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("부스 리뷰 작성에 성공했습니다."));
+        return new ResponseMessage("부스 리뷰 작성에 성공했습니다.");
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -43,7 +41,6 @@ public class BoothReviewController {
     @GetMapping("/booth/reviews/{review_id}")
     public BoothReviewResponse getReview(@PathVariable Long review_id){
         return BoothReviewResponse.of(boothReviewService.getBoothReview(review_id));
-
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -57,8 +54,10 @@ public class BoothReviewController {
 
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/booth/reviews/{review_id}")
-    public ResponseMessage deleteReview(Authentication authentication, @PathVariable Long review_id){
+    public ResponseMessage deleteReview(Authentication authentication,
+                                        @PathVariable Long review_id){
         boothReviewService.deleteReview(Long.parseLong(authentication.getName()), review_id);
         return new ResponseMessage("부스 리뷰 삭제에 성공했습니다.");
     }
+
 }

--- a/src/main/java/com/openbook/openbook/api/event/EventNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/event/EventNoticeController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,24 +28,26 @@ public class EventNoticeController {
 
     private final EventNoticeService eventNoticeService;
 
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/events/{event_id}/notices")
+    public ResponseMessage postNotice(Authentication authentication,
+                                      @PathVariable Long event_id,
+                                      @Valid EventNoticeRegisterRequest request) {
+        eventNoticeService.registerEventNotice(Long.valueOf(authentication.getName()), event_id, request);
+        return new ResponseMessage("공지 등록에 성공했습니다.");
+    }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/events/{event_id}/notices")
     public SliceResponse<EventNoticeResponse> getEventNotices(@PathVariable Long event_id,
                                                               @PageableDefault(size = 5) Pageable pageable) {
         return SliceResponse.of(eventNoticeService.getEventNotices(event_id, pageable).map(EventNoticeResponse::of));
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/events/notices/{notice_id}")
     public EventNoticeResponse getEventNotice(@PathVariable Long notice_id) {
         return EventNoticeResponse.of(eventNoticeService.getEventNotice(notice_id));
-    }
-
-    @PostMapping("/events/{event_id}/notices")
-    public ResponseEntity<ResponseMessage> postNotice(Authentication authentication,
-                                                      @PathVariable Long event_id,
-                                                      @Valid EventNoticeRegisterRequest request) {
-        eventNoticeService.registerEventNotice(Long.valueOf(authentication.getName()), event_id, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("공지 등록에 성공했습니다."));
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -58,10 +59,12 @@ public class EventNoticeController {
         return new ResponseMessage("공지 수정에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/events/notices/{notice_id}")
-    public ResponseEntity<ResponseMessage> deleteNotice(Authentication authentication,
-                                                        @PathVariable Long notice_id) {
+    public ResponseMessage deleteNotice(Authentication authentication,
+                                        @PathVariable Long notice_id) {
         eventNoticeService.deleteEventNotice(Long.valueOf(authentication.getName()), notice_id);
-        return ResponseEntity.ok(new ResponseMessage("공지 삭제에 성공했습니다."));
+        return new ResponseMessage("공지 삭제에 성공했습니다.");
     }
+
 }

--- a/src/main/java/com/openbook/openbook/api/event/EventReviewController.java
+++ b/src/main/java/com/openbook/openbook/api/event/EventReviewController.java
@@ -11,11 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -29,22 +27,25 @@ public class EventReviewController {
 
     private final EventReviewService eventReviewService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/event/review")
-    public ResponseEntity<ResponseMessage> postReview(Authentication authentication,
-                                                      @Valid EventReviewRegisterRequest request) {
+    public ResponseMessage postReview(Authentication authentication,
+                                      @Valid EventReviewRegisterRequest request) {
         eventReviewService.registerEventReview(Long.valueOf(authentication.getName()), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("행사 리뷰 작성에 성공했습니다."));
+        return new ResponseMessage("행사 리뷰 작성에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/event/reviews")
     public SliceResponse<EventReviewResponse> getReviews(@RequestParam(value = "event_id") Long request,
                                                          @PageableDefault(size = 5) Pageable pageable) {
         return SliceResponse.of(eventReviewService.getEventReviews(request, pageable).map(EventReviewResponse::of));
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/event/review/{review_id}")
-    public ResponseEntity<EventReviewResponse> getReview(@PathVariable Long review_id) {
-        return ResponseEntity.ok(EventReviewResponse.of(eventReviewService.getEventReview(review_id)));
+    public EventReviewResponse getReview(@PathVariable Long review_id) {
+        return EventReviewResponse.of(eventReviewService.getEventReview(review_id));
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -56,10 +57,12 @@ public class EventReviewController {
         return new ResponseMessage("리뷰 수정에 성공했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/event/reviews/{review_id}")
-    public ResponseEntity<ResponseMessage> deleteReview(Authentication authentication, @PathVariable Long review_id) {
+    public ResponseMessage deleteReview(Authentication authentication,
+                                        @PathVariable Long review_id) {
         eventReviewService.deleteReview(Long.parseLong(authentication.getName()), review_id);
-        return ResponseEntity.ok(new ResponseMessage("리뷰 삭제에 성공했습니다."));
+        return new ResponseMessage("리뷰 삭제에 성공했습니다.");
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/user/AlarmController.java
+++ b/src/main/java/com/openbook/openbook/api/user/AlarmController.java
@@ -8,11 +8,12 @@ import com.openbook.openbook.service.user.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,24 +22,28 @@ public class AlarmController {
 
     private final AlarmService alarmService;
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/alarms")
-    public SliceResponse<AlarmResponse> getAlarms(@PageableDefault(size = 5) Pageable pageable,
-                                                  Authentication authentication) {
-        return SliceResponse.of(alarmService.getAlarmData(pageable, Long.valueOf(authentication.getName()))
-                .map(AlarmResponse::of)
+    public SliceResponse<AlarmResponse> getAlarms(Authentication authentication,
+                                                  @PageableDefault(size = 5) Pageable pageable) {
+        return SliceResponse.of(alarmService.getAlarmData(
+                pageable, Long.valueOf(authentication.getName())).map(AlarmResponse::of)
         );
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/alarms")
-    public ResponseEntity<ResponseMessage> deleteAllAlarm(Authentication authentication) {
+    public ResponseMessage deleteAllAlarm(Authentication authentication) {
         alarmService.deleteAllAlarm(Long.valueOf(authentication.getName()));
-        return ResponseEntity.ok(new ResponseMessage("전체 알림을 삭제했습니다."));
+        return new ResponseMessage("전체 알림을 삭제했습니다.");
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/alarms/{alarmId}")
-    public ResponseEntity<ResponseMessage> deleteAlarm(Authentication authentication, @PathVariable Long alarmId) {
+    public ResponseMessage deleteAlarm(Authentication authentication,
+                                       @PathVariable Long alarmId) {
         alarmService.deleteAlarm(Long.valueOf(authentication.getName()), alarmId);
-        return ResponseEntity.ok(new ResponseMessage("알림을 삭제했습니다."));
+        return new ResponseMessage("알림을 삭제했습니다.");
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -44,8 +44,8 @@ public class BookmarkController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/bookmark-list")
     public SliceResponse<BookmarkResponse> findBookmarkList(Authentication authentication,
-                                                        @RequestParam(value = "type") String request,
-                                                        Pageable pageable) {
+                                                            @RequestParam(value = "type") String request,
+                                                            Pageable pageable) {
         return SliceResponse.of(bookmarkService
                 .findBookmarkList(Long.parseLong(authentication.getName()), request, pageable)
                 .map(BookmarkResponse::of)

--- a/src/main/java/com/openbook/openbook/api/user/UserController.java
+++ b/src/main/java/com/openbook/openbook/api/user/UserController.java
@@ -12,10 +12,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,24 +26,25 @@ public class UserController {
     final private TokenProvider tokenProvider;
     private final UserService userService;
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("user/access_token_info")
-    public ResponseEntity<TokenInfo> getTokenInfo(@NotNull HttpServletRequest request) {
+    public TokenInfo getTokenInfo(@NotNull HttpServletRequest request) {
         String token = tokenProvider.getTokenFrom(request);
-        return ResponseEntity.ok(tokenProvider.getInfoOf(token));
+        return tokenProvider.getInfoOf(token);
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/signup")
-    public ResponseEntity<ResponseMessage> signup(@RequestBody @Valid final SignUpRequest request) {
+    public ResponseMessage signup(@RequestBody @Valid final SignUpRequest request) {
         userService.signup(request);
-        return ResponseEntity.ok(new ResponseMessage("API 요청 성공"));
+        return new ResponseMessage("API 요청 성공");
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/login")
-    public ResponseEntity<Map<String, String>> login(@RequestBody @Valid final LoginRequest request) {
+    public Map<String, String> login(@RequestBody @Valid final LoginRequest request) {
         String token = userService.login(request);
-        return ResponseEntity.ok(Map.of("token", token));
+        return Map.of("token", token);
     }
-
-
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #200 

위 이슈에서 제안한 내용을 반영했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 전체적으로 ResponseEntity 대신 @ResponseStatus 를 사용하도록 변경했습니다.
- 추가적으로 컨트롤러 메서드의 파라미터의 순서를 규칙성이 있도록 변경했습니다.
세운 규칙은 다음과 같습니다.
```
1. Authentication
2. PathVariable
3. RequestBody
4. RequestParm
5. Pageable
```
- 오타를 발견한 부분의 메서드 명을 수정했습니다.
- 컨트롤러 내의 메서드 순서를 CRUD 순으로 배치되도록 변경했습니다.


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 해당 브런치에서는 ResponseStatus 만 고치고 파라미터 순서 등은 따로 브런치를 나누는 것이 좋았을텐데 고치다보니 함께 커밋해버렸습니다. 죄송합니다 😭 그래서 pr 제목(커밋 될 메시지) 의미가 정확하지 않게 되는데 혹시 아이디어 떠오르시는 것이 있으시면 말씀해주시면 감사하겠습니다! (ex Refactor: 컨트롤러 계층 코드)
- 위의 파라미터 순서나 메서드 순서는 코드 통일성을 위해 추가적으로 작업한 내용인데
혹시라도 관련해서 다른 의견 있으시거나 개선할 점 등 생각나시면 편하게 말씀해주세요! 🙂
만약 괜찮으시다면 남은 개발에도 적용시키면 좋을 것 같습니다!
