### PR TITLE
Feat: 부스 공지 삭제 API

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,7 +65,7 @@ jobs:
         script: |
           sudo docker ps
           sudo docker pull ${{ secrets.DOCKER_USERNAME }}/openbook
-          sudo docker run -d -p 8081:8080 ${{ secrets.DOCKER_USERNAME }}/openbook
+          sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/openbook
           sudo docker image prune -f
 
 

--- a/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
@@ -65,7 +65,7 @@ public class BoothNoticeController {
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/booths/notices/{notice_id}")
     public ResponseMessage deleteNotice(Authentication authentication,
-                                                        @PathVariable Long notice_id){
+                                        @PathVariable Long notice_id){
         boothNoticeService.deleteBoothNotice(Long.parseLong(authentication.getName()), notice_id);
         return new ResponseMessage("공지 삭제에 성공했습니다.");
     }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
@@ -15,6 +15,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,6 +54,14 @@ public class BoothNoticeController {
                                         @NotNull BoothNoticeModifyRequest request){
         boothNoticeService.modifyNotice(Long.parseLong(authentication.getName()), notice_id, request);
         return new ResponseMessage("공지 수정에 성공했습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @DeleteMapping("/booths/notices/{notice_id}")
+    public ResponseEntity<ResponseMessage> deleteNotice(Authentication authentication,
+                                                        @PathVariable Long notice_id){
+        boothNoticeService.deleteBoothNotice(Long.parseLong(authentication.getName()), notice_id);
+        return ResponseEntity.ok(new ResponseMessage("공지 삭제에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothNoticeController.java
@@ -64,10 +64,10 @@ public class BoothNoticeController {
 
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/booths/notices/{notice_id}")
-    public ResponseEntity<ResponseMessage> deleteNotice(Authentication authentication,
+    public ResponseMessage deleteNotice(Authentication authentication,
                                                         @PathVariable Long notice_id){
         boothNoticeService.deleteBoothNotice(Long.parseLong(authentication.getName()), notice_id);
-        return ResponseEntity.ok(new ResponseMessage("공지 삭제에 성공했습니다."));
+        return new ResponseMessage("공지 삭제에 성공했습니다.");
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
@@ -31,12 +31,6 @@ public class BoothNoticeService {
         );
     }
 
-    private void VerifyUserIsManagerOfBooth(BoothNotice boothNotice, long userId){
-        if(!boothNotice.getLinkedBooth().getManager().getId().equals(userId)){
-            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
-        }
-    }
-
     @Transactional(readOnly = true)
     public Slice<BoothNoticeDto> getBoothNotices(Long boothId, Pageable pageable){
         boothService.getBoothOrException(boothId);
@@ -89,6 +83,12 @@ public class BoothNoticeService {
         VerifyUserIsManagerOfBooth(notice, userId);
         s3Service.deleteFileFromS3(notice.getImageUrl());
         boothNoticeRepository.delete(notice);
+    }
+
+    private void VerifyUserIsManagerOfBooth(BoothNotice boothNotice, long userId){
+        if(!boothNotice.getLinkedBooth().getManager().getId().equals(userId)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
     }
 
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
@@ -77,4 +77,14 @@ public class BoothNoticeService {
                         .build());
     }
 
+    @Transactional
+    public void deleteBoothNotice(Long userId, Long noticeId){
+        BoothNotice notice = getBoothNoticeOrException(noticeId);
+        if(!notice.getLinkedBooth().getManager().getId().equals(userId)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        s3Service.deleteFileFromS3(notice.getImageUrl());
+        boothNoticeRepository.delete(notice);
+    }
+
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
@@ -31,6 +31,12 @@ public class BoothNoticeService {
         );
     }
 
+    private void VerifyUserIsManagerOfBooth(BoothNotice boothNotice, long userId){
+        if(!boothNotice.getLinkedBooth().getManager().getId().equals(userId)){
+            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
+
     @Transactional(readOnly = true)
     public Slice<BoothNoticeDto> getBoothNotices(Long boothId, Pageable pageable){
         boothService.getBoothOrException(boothId);
@@ -80,9 +86,7 @@ public class BoothNoticeService {
     @Transactional
     public void deleteBoothNotice(Long userId, Long noticeId){
         BoothNotice notice = getBoothNoticeOrException(noticeId);
-        if(!notice.getLinkedBooth().getManager().getId().equals(userId)){
-            throw new OpenBookException(ErrorCode.FORBIDDEN_ACCESS);
-        }
+        VerifyUserIsManagerOfBooth(notice, userId);
         s3Service.deleteFileFromS3(notice.getImageUrl());
         boothNoticeRepository.delete(notice);
     }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #267 
DELETE /booths/notices/{notice_id}

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- controller 클래스에 공지 삭제 추가
- service 클래스에 공지 삭제 메소드 추가
- 공지 삭제시 로그인 유저가 부스 관리자인지 판별하는 메소드를 따로 만들어서 분리
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
<img width="665" alt="image" src="https://github.com/user-attachments/assets/83058fa9-641d-4c4f-b32e-77d04d1c27c9">

- 관리자가 아닌 사람이 삭제를 할 경우
<img width="659" alt="image" src="https://github.com/user-attachments/assets/952c94b6-be55-41e5-884a-2cdaef8584a3">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 저번 리팩토링 과정 때 TODO로 주석 처리하신 부분중에 권한 확인 클래스 따로 설정 하신 다고 본 것 같은데 우선 부스 공지 쪽에서도 권한을 확인하는 로직이 중복되어 사용되는 것 같아서 메소드 분리를 해보았습니다. 괜찮으시다면 사용된 로직 부분은 이 메소드를 활용해볼까 하는데 의견 남겨주세요!
- 그 외 질문이나 의견 있으시면 리뷰 남겨주세요! 