### PR TITLE
Fix: 공지 등록시 이미지 null 일 때 처리

### DIFF
--- a/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothNoticeService.java
@@ -56,7 +56,7 @@ public class BoothNoticeService {
                         .title(request.title())
                         .content(request.content())
                         .type(request.noticeType())
-                        .imageUrl(s3Service.uploadFileAndGetUrl(request.image()))
+                        .imageUrl((request.image() != null)?s3Service.uploadFileAndGetUrl(request.image()):null)
                         .linkedBooth(booth)
                         .build()
         );

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReviewService.java
@@ -40,13 +40,12 @@ public class BoothReviewService {
         User user = userService.getUserOrException(userId);
         Booth booth = boothService.getBoothOrException(request.booth_id());
         checkReviewable(booth, userId);
-        String image = (request.image()!=null)?s3Service.uploadFileAndGetUrl(request.image()):null;
         boothReviewRepository.save(BoothReview.builder()
                 .reviewer(user)
                 .linkedBooth(booth)
                 .star(request.star())
                 .content(request.content())
-                .imageUrl(image)
+                .imageUrl((request.image()!=null) ? s3Service.uploadFileAndGetUrl(request.image()):null)
                 .build()
         );
     }

--- a/src/main/java/com/openbook/openbook/service/event/EventNoticeService.java
+++ b/src/main/java/com/openbook/openbook/service/event/EventNoticeService.java
@@ -52,7 +52,7 @@ public class EventNoticeService {
                 .title(request.title())
                 .content(request.content())
                 .type(request.noticeType())
-                .imageUrl(s3Service.uploadFileAndGetUrl(request.image()))
+                .imageUrl((request.image()!=null)?s3Service.uploadFileAndGetUrl(request.image()):null)
                 .linkedEvent(event)
                 .build()
         );


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #269
- 행사 부스 모두 공지 등록시 이미지가 null 값 일 때 발생하는 nullpointerException 에러를 해결했습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- 공지 객체 생성시 imageUrl 값에 null 일경우의 삼항 연산자 대입
- 부스 리뷰 생성시 image 변수를 만들어서 null 값 처리 후 객체 생성을 했던 과정을 지우고 바로 객체 생성시에 null 값 처리를 동시에 하도록 했습니다.
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
ex) 부스 공지 등록
POST /booths/boothId/notices
<img width="711" alt="image" src="https://github.com/user-attachments/assets/68421857-2fc5-4a32-91c4-bab5d2d5b009">
<img width="821" alt="image" src="https://github.com/user-attachments/assets/1026a385-7c40-4431-9380-790ad3dda6be">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
의견이나 질문 있으시면 리뷰 남겨주세요!