### PR TITLE
Refactor: 예약 등록시 여러 날짜와 시간 등록 관련 개선

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/request/ReserveRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/ReserveRegistrationRequest.java
@@ -13,7 +13,7 @@ public record ReserveRegistrationRequest(
         @NotBlank String description,
         @NotNull int price,
         MultipartFile image,
-        @NotNull LocalDate date,
+        @NotNull List<LocalDate> date,
         @NotEmpty List<String> times
         ) {
 }

--- a/src/main/java/com/openbook/openbook/api/booth/request/ReserveRegistrationRequest.java
+++ b/src/main/java/com/openbook/openbook/api/booth/request/ReserveRegistrationRequest.java
@@ -13,7 +13,7 @@ public record ReserveRegistrationRequest(
         @NotBlank String description,
         @NotNull int price,
         MultipartFile image,
-        @NotNull List<LocalDate> date,
+        @NotNull List<LocalDate> dates,
         @NotEmpty List<String> times
         ) {
 }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -82,10 +82,10 @@ public class BoothReservationService {
     @Transactional
     public void addReservation(Long userId, ReserveRegistrationRequest request, Long boothId) {
         Booth booth = getValidBoothOrException(userId, boothId);
-        checkAvailableDate(request.date(), booth);
+        checkAvailableDate(request.dates(), booth);
         checkDuplicateDates(request, booth);
 
-        for(LocalDate date : request.date()){
+        for(LocalDate date : request.dates()){
             BoothReservation reservation = boothReservationRepository.save(
                     BoothReservation.builder()
                             .name(request.name())
@@ -115,7 +115,7 @@ public class BoothReservationService {
     }
 
     private void checkDuplicateDates(ReserveRegistrationRequest request, Booth booth){
-        for(LocalDate date : request.date()){
+        for(LocalDate date : request.dates()){
             if(boothReservationRepository.existsByLinkedBoothIdAndDateAndName(booth.getId(), date, request.name())){
                 throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
             }

--- a/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothReservationService.java
@@ -16,6 +16,8 @@ import com.openbook.openbook.service.user.AlarmService;
 import com.openbook.openbook.util.S3Service;
 import com.openbook.openbook.domain.user.User;
 import com.openbook.openbook.service.user.UserService;
+
+import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -80,38 +82,45 @@ public class BoothReservationService {
     @Transactional
     public void addReservation(Long userId, ReserveRegistrationRequest request, Long boothId) {
         Booth booth = getValidBoothOrException(userId, boothId);
-        checkAvailableDate(request, booth);
+        checkAvailableDate(request.date(), booth);
         checkDuplicateDates(request, booth);
 
-        BoothReservation reservation = boothReservationRepository.save(
-                BoothReservation.builder()
-                        .name(request.name())
-                        .description(request.description())
-                        .price(request.price())
-                        .date(request.date())
-                        .imageUrl(s3Service.uploadFileAndGetUrl(request.image()))
-                        .linkedBooth(booth)
-                        .build()
-        );
-
-        reservationDetailService.createReservationDetail(request.times(), reservation, booth);
+        for(LocalDate date : request.date()){
+            BoothReservation reservation = boothReservationRepository.save(
+                    BoothReservation.builder()
+                            .name(request.name())
+                            .description(request.description())
+                            .price(request.price())
+                            .date(date)
+                            .imageUrl(s3Service.uploadFileAndGetUrl(request.image()))
+                            .linkedBooth(booth)
+                            .build()
+            );
+            reservationDetailService.createReservationDetail(request.times(), reservation, booth);
+        }
     }
 
     public List<BoothReservation> getBoothReservations(Long boothId){
         return boothReservationRepository.findBoothReservationByLinkedBoothId(boothId);
     }
 
-    private void checkAvailableDate(ReserveRegistrationRequest request, Booth booth){
-        if(request.date().isBefore(booth.getLinkedEvent().getOpenDate())
-                || request.date().isAfter(booth.getLinkedEvent().getCloseDate())){
-            throw new OpenBookException(ErrorCode.INVALID_RESERVED_DATE);
+    private void checkAvailableDate(List<LocalDate> dates, Booth booth){
+        for(LocalDate date : dates){
+            if(date.isBefore(booth.getLinkedEvent().getOpenDate())
+                    || date.isAfter(booth.getLinkedEvent().getCloseDate())){
+                throw new OpenBookException(ErrorCode.INVALID_RESERVED_DATE);
+            }
         }
+
     }
 
     private void checkDuplicateDates(ReserveRegistrationRequest request, Booth booth){
-        if(boothReservationRepository.existsByLinkedBoothIdAndDateAndName(booth.getId(), request.date(), request.name())){
-            throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
+        for(LocalDate date : request.date()){
+            if(boothReservationRepository.existsByLinkedBoothIdAndDateAndName(booth.getId(), date, request.name())){
+                throw new OpenBookException(ErrorCode.ALREADY_RESERVED_DATE);
+            }
         }
+
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #273 
ISSUE에 작성한 바와 같이 등록할 예약 date 데이터 정보들을 리스트에 담아 날짜와 시간 정보를 모두 한번에 입력 받아 저장하도록 구현했습니다.
즉 요청한 날짜들은 같은 시간대를 저장하게 됩니다.
추후 각 날짜마다의 시간대를 조정을 원한다면 수정 API를 통해 사용자가 시간대를 조율 할 수 있습니다.
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- date 를 리스트형식으로 요청 받게 함
- 요청 한 date 데이터들을 이용해서 각각 예약 객체를 생성하고 생성한 객체들을 통해 시간 데이터를 저장하게 함
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
request data
```
name: 아이스크림 만들기
description: 직접 만들 수 있어요
price: 0
image: imagedata
dates: [2024-11-01, 2024-11-02, 2024-11-03]
times: [10:00, 11:00, 12:00]
```
result
[booth_reservation]
![image](https://github.com/user-attachments/assets/1add45b2-1dea-4969-a50c-37129417b1b9)
[booth_reservation_detail]
![image](https://github.com/user-attachments/assets/d281adee-7c7d-41c5-b026-0b9f63b5bfe8)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 이슈에 좀 더 상세히 작성해 두었지만 현재 개발 해본 사항은 현재 프론트 측에서 구성하신 내용을 바탕으로 생각해서 개발했습니다. 혹시 다른 의견이나 질문 사항 있으시면 리뷰 남겨주세요!