### PR TITLE
Feat: 부스 목록 조회에서의 행사 필터링 기능 추가

### DIFF
--- a/src/main/java/com/openbook/openbook/api/booth/BoothController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothController.java
@@ -45,11 +45,8 @@ public class BoothController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/booths")
-    public SliceResponse<BoothBasicData> getBooths(@PageableDefault(size = 6) Pageable pageable){
-        return SliceResponse.of(
-                boothService.getBooths(pageable)
-                        .map(BoothBasicData::of)
-        );
+    public SliceResponse<BoothBasicData> getBooths(@PageableDefault(size = 6) Pageable pageable,
+                                                   @RequestParam(defaultValue = "ALL") String event){
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/openbook/openbook/api/booth/BoothController.java
+++ b/src/main/java/com/openbook/openbook/api/booth/BoothController.java
@@ -47,6 +47,7 @@ public class BoothController {
     @GetMapping("/booths")
     public SliceResponse<BoothBasicData> getBooths(@PageableDefault(size = 6) Pageable pageable,
                                                    @RequestParam(defaultValue = "ALL") String event){
+        return SliceResponse.of(boothService.getBooths(pageable, event).map(BoothBasicData::of));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/openbook/openbook/repository/booth/BoothRepository.java
+++ b/src/main/java/com/openbook/openbook/repository/booth/BoothRepository.java
@@ -23,7 +23,9 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     @Query("SELECT b FROM Booth b WHERE b.status=:boothStatus")
     Slice<Booth> findAllByStatus(Pageable pageable, BoothStatus boothStatus);
-    
+
+    Slice<Booth> findAllByLinkedEventIdAndStatus(Pageable pageable, Long eventId, BoothStatus boothStatus);
+
     int countByLinkedEvent(Event linkedEvent);
 
     @Query("SELECT b FROM Booth b WHERE b.name LIKE %:boothName% AND b.status =:boothStatus")

--- a/src/main/java/com/openbook/openbook/service/booth/BoothService.java
+++ b/src/main/java/com/openbook/openbook/service/booth/BoothService.java
@@ -99,10 +99,14 @@ public class BoothService {
 
 
     @Transactional(readOnly = true)
-    public Slice<BoothDto> getBooths(Pageable pageable) {
-        return boothRepository.findAllByStatus(pageable, BoothStatus.APPROVE).map(booth ->
-                BoothDto.of(booth, boothAreaService.getBoothAreasByBoothId(booth.getId()))
-        );
+    public Slice<BoothDto> getBooths(Pageable pageable, String event) {
+        if(event.equals("ALL")) {
+            return boothRepository.findAllByStatus(pageable, BoothStatus.APPROVE).map(booth ->
+                    BoothDto.of(booth, boothAreaService.getBoothAreasByBoothId(booth.getId()))
+            );
+        }
+        return boothRepository.findAllByLinkedEventIdAndStatus(pageable, Long.parseLong(event), BoothStatus.APPROVE)
+                .map(booth -> BoothDto.of(booth, boothAreaService.getBoothAreasByBoothId(booth.getId())));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #240 
- 부스 목록을 행사별로 필터링할 수 있도록 기능을 추가했습니다.
- 기존에 있던 부스 목록 조회 API "/booths" 에 event 라는 param을 추가했습니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- **BoothController** 기존 getBooths 메서드에 event 파라미터 추가
- **BoothService** 기존 getBooths 메서드에 행사 필터링 기능을 추가


## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**요청**
- `GET` {{local}}/booths?event=70

**응답**
- 해당 행사의 부스만 조회됩니다.
- ![image](https://github.com/user-attachments/assets/512e93e3-a860-4f57-a67f-be502b4c1113)



## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 행사 아이디가 없는 경우에도 오류가 아니라 빈 값으로 나와서 해당 처리는 따로 하지 않았습니다!
- 궁금한 점, 개선 방안 등 의견 편하게 주세요! 😃