### PR TITLE
Feat: 유저 프로필 정보 조회 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/user/UserController.java
+++ b/src/main/java/com/openbook/openbook/api/user/UserController.java
@@ -1,6 +1,7 @@
 package com.openbook.openbook.api.user;
 
 
+import com.openbook.openbook.api.user.response.UserProfileResponse;
 import com.openbook.openbook.util.TokenProvider;
 import com.openbook.openbook.api.ResponseMessage;
 import com.openbook.openbook.api.user.response.TokenInfo;
@@ -13,6 +14,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,6 +47,12 @@ public class UserController {
     public Map<String, String> login(@RequestBody @Valid final LoginRequest request) {
         String token = userService.login(request);
         return Map.of("token", token);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/manage/profile")
+    public UserProfileResponse getProfile(Authentication authentication){
+        return UserProfileResponse.of(userService.getUserProfile(Long.valueOf(authentication.getName())));
     }
 
 }

--- a/src/main/java/com/openbook/openbook/api/user/response/UserProfileResponse.java
+++ b/src/main/java/com/openbook/openbook/api/user/response/UserProfileResponse.java
@@ -1,0 +1,19 @@
+package com.openbook.openbook.api.user.response;
+
+import com.openbook.openbook.service.user.dto.UserProfileDto;
+
+public record UserProfileResponse(
+        Long id,
+        String name,
+        String nickname,
+        String email
+) {
+    public static UserProfileResponse of(UserProfileDto dto){
+        return new UserProfileResponse(
+                dto.id(),
+                dto.name(),
+                dto.nickname(),
+                dto.email()
+        );
+    }
+}

--- a/src/main/java/com/openbook/openbook/service/user/UserService.java
+++ b/src/main/java/com/openbook/openbook/service/user/UserService.java
@@ -2,6 +2,7 @@ package com.openbook.openbook.service.user;
 
 import com.openbook.openbook.exception.ErrorCode;
 import com.openbook.openbook.exception.OpenBookException;
+import com.openbook.openbook.service.user.dto.UserProfileDto;
 import com.openbook.openbook.util.TokenProvider;
 import com.openbook.openbook.api.user.request.LoginRequest;
 import com.openbook.openbook.api.user.request.SignUpRequest;
@@ -58,6 +59,12 @@ public class UserService {
         return tokenProvider.generateToken(user.getId(), user.getNickname(), user.getRole().name());
     }
 
+    @Transactional(readOnly = true)
+    public UserProfileDto getUserProfile(Long userId){
+        User user = getUserOrException(userId);
+        return UserProfileDto.of(user);
+    }
+
     public Optional<User> getUserByEmail(final String email) {
         return userRepository.findByEmail(email);
     }
@@ -67,6 +74,4 @@ public class UserService {
                 new OpenBookException(ErrorCode.USER_NOT_FOUND)
         );
     }
-
-
 }

--- a/src/main/java/com/openbook/openbook/service/user/dto/UserProfileDto.java
+++ b/src/main/java/com/openbook/openbook/service/user/dto/UserProfileDto.java
@@ -1,0 +1,19 @@
+package com.openbook.openbook.service.user.dto;
+
+import com.openbook.openbook.domain.user.User;
+
+public record UserProfileDto(
+        Long id,
+        String name,
+        String nickname,
+        String email
+) {
+    public static UserProfileDto of(User user){
+        return new UserProfileDto(
+                user.getId(),
+                user.getName(),
+                user.getNickname(),
+                user.getEmail()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #279 
GET /manage/profile
## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
- UserProfileResponse와 DTO를 추가해서 마이페이지에 필요한 정보들만 반환
- UserService 클래스에 유저 객체를 반환하는 getUserProfile 메소드 추가
- UserController 클래스에 getProfile 추가
## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 성공 시
<img width="756" alt="image" src="https://github.com/user-attachments/assets/0409e085-f03e-46e1-b6a6-7b42565e3280">

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 엔드포인트는 유저가 관리하는 행사, 부스 조회시 manage를 붙였기 때문에 프로필 정보 반환 또한 manage/를 앞에 붙여 두었습니다.
- 회원 가입시 등록하는 데이터 정보가 적기 때문에 반환하는 데이터도 그렇게 많지 않아서 프론트 화면에서 좀 빈약하게 보일까 걱정이 되긴합니다 😅 추후 회원가입시 더 저장하면 좋을 데이터 생각해봐도 좋을 것 같네요.
- 다른 의견이나 질문 사항 있으시면 리뷰 남겨주세요! 😀