### PR TITLE
Feat: 북마크 여부 확인 API

### DIFF
--- a/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
+++ b/src/main/java/com/openbook/openbook/api/user/BookmarkController.java
@@ -5,8 +5,10 @@ import com.openbook.openbook.api.ResponseMessage;
 import com.openbook.openbook.api.SliceResponse;
 import com.openbook.openbook.api.user.request.BookmarkRequest;
 import com.openbook.openbook.api.user.response.BookmarkResponse;
+import com.openbook.openbook.domain.user.dto.BookmarkType;
 import com.openbook.openbook.service.user.BookmarkService;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -24,6 +26,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/bookmark")
+    public Map<String, Boolean> bookmarked(Authentication authentication,
+                                           @RequestParam(value = "type") BookmarkType type,
+                                           @RequestParam(value = "resourceId") long resourceId) {
+        Boolean bookmark = bookmarkService.isUserBookmark(Long.parseLong(authentication.getName()), type, resourceId);
+        return Map.of("bookmark", bookmark);
+    }
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/bookmark")

--- a/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
+++ b/src/main/java/com/openbook/openbook/service/user/BookmarkService.java
@@ -28,11 +28,15 @@ public class BookmarkService {
 
     private final BookmarkRepository bookmarkRepository;
 
+    public boolean isUserBookmark(long userId, BookmarkType type, long resourceId) {
+        return bookmarkRepository.existsByUserIdAndResourceIdAndBookmarkType(userId, resourceId, type);
+    }
+
     @Transactional
     public void createBookmark(long userId, BookmarkRequest request) {
         User user = userService.getUserOrException(userId);
         BookmarkType type = BookmarkType.fromString(request.type());
-        if(bookmarkRepository.existsByUserIdAndResourceIdAndBookmarkType(userId, request.resourceId(), type)) {
+        if(isUserBookmark(userId, type, request.resourceId())) {
             throw new OpenBookException(ErrorCode.ALREADY_BOOKMARK);
         }
         bookmarkRepository.save( Bookmark.builder()


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #280 

현재 로그인한 유저가 파라미터와 일치하는 리소스에 북마크 했는지 확인하는 API를 개발했습니다.

**request**
- GET
- /bookmark

**param**
- type (EVENT/BOOTH)
- resourceId

파라미터를 모두 입력하지 않을 경우 400코드와 함께 오류메세지를 반환합니다.

## Key Changes
<!-- 주요 수정사항을 기재해주세요 -->
기존 BookmarkService 에서 유저의 북마크 여부 확인하는 로직을 다른 메서드로 분리해서 사용

## Testing
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**성공 (북마크한 경우)**
`GET` {{local}}/bookmark?type=EVENT&resourceId=70
![image](https://github.com/user-attachments/assets/80f1bbcb-4aad-4a27-9d2c-46c9fe5cfdf2)

**성공 (북마크하지 않은 경우)**
`GET`  {{local}}/bookmark?type=BOOTH&resourceId=72
![image](https://github.com/user-attachments/assets/851b02dc-e275-4b03-adf8-1b9e050b7a20)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 행사 부스 조회가 로그인 없이도 돼서 북마크 여부를 조회 결과에 포함시키기 복잡해 api를 따로 분리했습니다.
매니저 여부 확인하듯이 프론트 쪽에서 토큰 정보가 null 이 아닌 경우 해당 api를 호출하도록 하면 될 것 같은데 해당 내용은 회의 때 전달하도록 하겠습니다! 
- 궁금하신 점, 개선할 점 등 편하게 의견 주세요! 😃